### PR TITLE
fix: change inbox query to use user_id instead of email

### DIFF
--- a/src/app/api/echo_routes.py
+++ b/src/app/api/echo_routes.py
@@ -226,13 +226,13 @@ async def list_received_echoes(
     current_user: Dict[str, Any] = Depends(get_current_user),
 ):
     """List echoes received by the current user (inbox view)."""
-    user_email = current_user.get("email", "")
+    user_id = current_user.get("id", "")
 
-    if not user_email:
-        raise HTTPException(status_code=400, detail="User email not found")
+    if not user_id:
+        raise HTTPException(status_code=400, detail="User ID not found")
 
     echoes = await echo_service.get_received_echoes(
-        recipient_email=user_email,
+        user_id=user_id,
         category=category,
         sender_id=sender_id,
     )

--- a/src/app/services/echo_service.py
+++ b/src/app/services/echo_service.py
@@ -328,7 +328,7 @@ class EchoService:
 
     async def get_received_echoes(
         self,
-        recipient_email: str,
+        user_id: str,
         category: Optional[str] = None,
         sender_id: Optional[str] = None,
     ) -> List[Echo]:
@@ -337,7 +337,7 @@ class EchoService:
         Only returns RELEASED echoes.
 
         Args:
-            recipient_email: Recipient's email
+            user_id: User's ID (Cognito sub)
             category: Filter by category
             sender_id: Filter by sender
 
@@ -345,23 +345,23 @@ class EchoService:
             List of received echoes
         """
         try:
-            # First, find recipient by email to get recipient_id
+            # First, find recipients for this user to get recipient_ids
             async with self.session.resource(
                 "dynamodb", **self._get_dynamodb_kwargs()
             ) as dynamodb:
                 recipients_table = await dynamodb.Table(self.recipients_table)
 
-                # Query by email index
+                # Query by user-recipients-index
                 recipient_response = await recipients_table.query(
-                    IndexName="email-index",
-                    KeyConditionExpression="email = :email",
-                    ExpressionAttributeValues={":email": recipient_email},
+                    IndexName="user-recipients-index",
+                    KeyConditionExpression="user_id = :uid",
+                    ExpressionAttributeValues={":uid": user_id},
                 )
 
                 if not recipient_response.get("Items"):
                     return []
 
-                # Collect all recipient IDs for this email
+                # Collect all recipient IDs for this user
                 recipient_ids = [
                     item["recipient_id"] for item in recipient_response["Items"]
                 ]


### PR DESCRIPTION
Changed get_received_echoes to query recipients by user_id instead of email. This fixes inbox visibility issues where recipient email does not match Cognito user email.

- Modified get_received_echoes to accept user_id parameter
- Changed query to use user-recipients-index GSI instead of email-index
- Updated inbox endpoint to pass user_id from JWT instead of email
- All 50 tests passing, no type errors