### PR TITLE
fix: allow media attachment to RELEASED echoes (fixes video/audio upl…

### DIFF
--- a/docs/ECHO_MEDIA_ATTACHMENT_FIX.md
+++ b/docs/ECHO_MEDIA_ATTACHMENT_FIX.md
@@ -1,0 +1,150 @@
+# Echo Media Attachment Fix
+
+## Problem
+
+Videos and audio files were not being attached to echoes when uploaded. The workflow was:
+
+1. User creates echo with recipient (no `release_date`) → Echo auto-released (status = RELEASED)
+2. User gets upload URL → Success
+3. User uploads file to S3 → Success
+4. User PATCHes echo with `media_url` → **FAILED: "Cannot update locked or released echo"**
+
+## Root Cause
+
+The `update_echo()` method in [echo_service.py](../src/app/services/echo_service.py) blocked ALL updates to RELEASED echoes, including media attachment. This was too restrictive for the upload workflow where:
+
+- Echo is created and released immediately (when it has a recipient)
+- Media is uploaded separately (S3 direct upload)
+- Media URL is attached via PATCH after upload completes
+
+## Solution
+
+Allow media attachment as a **special case** on RELEASED echoes, with these constraints:
+
+1. **Only `media_url` and optionally `echo_type`** can be updated
+2. **Only if `media_url` is currently empty** (first-time attachment only)
+3. **No other fields** can be updated together with media
+
+### Code Changes
+
+**File:** `src/app/services/echo_service.py` ([echo_service.py](../src/app/services/echo_service.py#L479-L520))
+
+```python
+# Special case: Allow media attachment on RELEASED echoes (first-time only)
+is_media_only_update = (
+    "media_url" in data
+    and set(data.keys()) <= {"media_url", "echo_type"}
+    and not echo.media_url  # Only if media_url is currently empty
+)
+
+# Prevent updates to locked/released echoes (except first-time media attachment)
+if echo.status != EchoStatus.DRAFT and not is_media_only_update:
+    logger.warning(
+        f"Attempted to update non-draft echo {echo_id} (status={echo.status.value})"
+    )
+    raise InternalServerError("Cannot update locked or released echo")
+
+# Apply updates
+if "media_url" in data:
+    echo.media_url = data["media_url"]
+    logger.info(
+        f"Attached media to echo {echo_id} (status={echo.status.value})"
+    )
+if "echo_type" in data:
+    try:
+        echo.echo_type = EchoType(data["echo_type"])
+    except (ValueError, KeyError):
+        pass  # Keep existing type if invalid
+```
+
+## Test Coverage
+
+**File:** `tests/test_echo_media_attachment.py` ([test_echo_media_attachment.py](../tests/test_echo_media_attachment.py))
+
+**6 comprehensive tests (all passing):**
+
+1. ✅ `test_can_attach_media_to_released_echo` - First-time media attachment works
+2. ✅ `test_can_attach_media_and_echo_type_to_released_echo` - Media + type update works
+3. ✅ `test_cannot_update_other_fields_on_released_echo` - Title/content updates still blocked
+4. ✅ `test_cannot_attach_media_twice` - Cannot replace existing media
+5. ✅ `test_cannot_update_media_with_other_fields_on_released_echo` - Media + other field blocked
+6. ✅ `test_draft_echo_can_be_updated_freely` - DRAFT echoes unchanged (can update any field)
+
+## Workflow After Fix
+
+1. User creates echo with recipient (no `release_date`) → Echo auto-released ✅
+2. User gets upload URL → Success ✅
+3. User uploads file to S3 → Success ✅
+4. User PATCHes echo with `media_url` → **SUCCESS** ✅ (now allowed as special case)
+5. Echo displays with video/audio in app ✅
+
+## Security & Validation
+
+- **First-time only:** Cannot replace existing media (prevents accidental overwrites)
+- **Owner-only:** Only echo owner can update (existing authorization still applies)
+- **Immutable after first attach:** Once media is attached, echo becomes immutable
+- **Type safety:** Invalid `echo_type` values are ignored (keeps existing type)
+
+## API Behavior
+
+**PATCH** `/api/echoes/{echo_id}`
+
+**Allowed on RELEASED echoes:**
+```json
+{
+  "media_url": "s3://bucket/user-123/echo-456.mp4"
+}
+```
+
+```json
+{
+  "media_url": "s3://bucket/user-123/echo-456.mp4",
+  "echo_type": "VIDEO"
+}
+```
+
+**Still blocked on RELEASED echoes:**
+```json
+{
+  "title": "New Title"  // ❌ Cannot update metadata
+}
+```
+
+```json
+{
+  "media_url": "s3://new-file.mp4",
+  "media_url": "s3://existing-file.mp4"  // ❌ Already has media
+}
+```
+
+```json
+{
+  "media_url": "s3://file.mp4",
+  "title": "New Title"  // ❌ Cannot mix media with other fields
+}
+```
+
+## Related Issues
+
+- Original issue: Video/audio uploads not attaching to echoes
+- Related fix: [Recipient access control](./RECIPIENT_ECHO_ACCESS_FIX.md)
+- Related fix: [Storage quota Decimal handling](./STORAGE_QUOTA_DECIMAL_FIX.md)
+
+## Deployment
+
+- Status: ✅ **Ready for deployment**
+- Tests: ✅ All passing (6/6)
+- Breaking changes: None
+- Backward compatible: Yes
+
+## Verification
+
+After deployment, verify:
+
+1. Create echo with recipient → Echo auto-releases
+2. Request upload URL for video → Get presigned S3 URL
+3. Upload video to S3 → File uploads successfully
+4. PATCH echo with media_url → **Should succeed (200 OK)**
+5. View echo in app → Video displays and plays
+6. Try to update title → **Should fail (400 Bad Request)**
+7. Try to upload different video → **Should fail (400 Bad Request)**

--- a/docs/RECIPIENT_ECHO_ACCESS_FIX.md
+++ b/docs/RECIPIENT_ECHO_ACCESS_FIX.md
@@ -1,0 +1,113 @@
+# Recipient Echo Access Fix
+
+## Issue
+Recipients were unable to view echoes sent to them. When a user tried to view an echo where they were the recipient (not the owner), they received a "404 Echo not found" error.
+
+## Root Cause
+The `get_echo()` method in `echo_service.py` only checked if the requesting user was the **owner** of the echo:
+
+```python
+# OLD CODE (BROKEN)
+if echo.user_id != user_id:
+    logger.warning(f"User {user_id} attempted to access echo {echo_id} owned by {echo.user_id}")
+    return None
+```
+
+This meant:
+- Owner user A creates echo and sends it to recipient B
+- Recipient B (who has `recipient_user_id` linked to their account) tries to view the echo
+- Access denied because B is not the owner → 404 error
+
+## Solution
+Modified `get_echo()` to allow both **owners** AND **recipients** to view echoes:
+
+```python
+# NEW CODE (FIXED)
+is_owner = echo.user_id == user_id
+is_recipient = False
+
+# Check if user is the recipient
+if not is_owner and echo.recipient_id:
+    recipient = await self.get_recipient(echo.recipient_id, echo.user_id)
+    if recipient and recipient.recipient_user_id == user_id:
+        is_recipient = True
+
+if not is_owner and not is_recipient:
+    return None  # Deny access
+```
+
+### Access Control Logic
+1. **Owner access**: User owns the echo (`echo.user_id == user_id`) → Allow
+2. **Recipient access**:
+   - Echo has a `recipient_id`
+   - Fetch the recipient record
+   - Check if `recipient.recipient_user_id == user_id` → Allow
+3. **No access**: User is neither owner nor recipient → Deny (404)
+
+## Additional Improvements
+
+### 1. Optimization: Recipient Caching
+The fix caches the recipient lookup to avoid duplicate DynamoDB calls:
+
+```python
+cached_recipient = None
+
+# Check recipient access
+if not is_owner and echo.recipient_id:
+    recipient = await self.get_recipient(echo.recipient_id, echo.user_id)
+    if recipient and recipient.recipient_user_id == user_id:
+        is_recipient = True
+        cached_recipient = recipient  # Cache it
+
+# Later: Enrich echo with recipient details
+recipient = cached_recipient or await self.get_recipient(...)  # Use cache
+```
+
+This avoids making two identical queries when a recipient views an echo.
+
+### 2. Bug Fix: Recipient Enrichment
+Fixed recipient enrichment to always fetch from the **echo owner's** recipients:
+
+```python
+# OLD (BROKEN when recipient views):
+recipient = await self.get_recipient(echo.recipient_id, user_id)
+
+# NEW (CORRECT):
+recipient = await self.get_recipient(echo.recipient_id, echo.user_id)
+```
+
+The `user_id` parameter specifies whose recipient list to query. When a recipient views an echo, `user_id` is the recipient's ID, not the owner's. This would fail to find the recipient record since it belongs to the owner.
+
+## Testing
+Created comprehensive tests in `tests/test_recipient_access.py`:
+
+1. **test_recipient_can_view_echo_sent_to_them**: Verifies recipients with linked accounts can view echoes
+2. **test_recipient_without_user_account_cannot_view_echo**: Verifies unlinked recipients (no `recipient_user_id`) cannot view echoes
+
+Both tests pass ✅
+
+## Files Modified
+- `src/app/services/echo_service.py` - Updated `get_echo()` method (lines 237-267)
+- `tests/test_recipient_access.py` - New test file with 2 comprehensive tests
+
+## Logs
+When a recipient successfully accesses an echo, you'll see:
+```
+User {recipient_user_id} accessing echo {echo_id} as recipient (recipient_id: {recipient_id})
+```
+
+When access is denied:
+```
+User {user_id} attempted to access echo {echo_id} owned by {owner_id} - not owner or recipient
+```
+
+## Deployment
+After deploying this fix, recipients will be able to:
+- View echoes sent to them in their inbox
+- Open and read echo details
+- See media content (with signed URLs)
+
+The fix maintains security:
+- Only owners and intended recipients can access echoes
+- Other users receive 404 (not 403 to avoid leaking echo existence)
+- Recipient access requires `recipient_user_id` linking (user must have an account)

--- a/docs/STORAGE_QUOTA_DECIMAL_FIX.md
+++ b/docs/STORAGE_QUOTA_DECIMAL_FIX.md
@@ -1,0 +1,94 @@
+# Storage Quota Decimal Type Fix
+
+## Issue
+Voice and video uploads were failing with the error:
+```
+ERROR - Error checking quota for user: unsupported operand type(s) for /: 'float' and 'decimal.Decimal'
+```
+
+This prevented users from uploading media files to their echoes.
+
+## Root Cause
+DynamoDB returns numeric values as `Decimal` objects (from the `boto3` library), but Python arithmetic operations require consistent types. The storage quota service was attempting to perform division between:
+- `float` values (from `calculate_user_storage_usage()`)
+- `Decimal` values (from DynamoDB fields like `user_profile.echo_vault_quota_gb`)
+
+Python does not allow direct arithmetic operations between `float` and `Decimal` types without explicit conversion, causing a `TypeError`.
+
+## Affected Code Locations
+
+### 1. `check_quota_exceeded()` - Line 129
+**Problem:**
+```python
+quota_gb = user_profile.echo_vault_quota_gb  # Returns Decimal from DynamoDB
+percent_used = (current_usage / quota_gb * 100)  # current_usage is float
+# TypeError: unsupported operand type(s) for /: 'float' and 'decimal.Decimal'
+```
+
+**Fix:**
+```python
+# Convert Decimal to float for arithmetic operations
+quota_gb = float(user_profile.echo_vault_quota_gb) if user_profile.echo_vault_quota_gb else 0.0
+percent_used = (current_usage / quota_gb * 100) if quota_gb > 0 else 0
+```
+
+### 2. `can_upload()` - Line 169
+**Problem:**
+```python
+projected_usage = quota_status["usage_gb"] + file_size_gb
+# TypeError if quota_status["usage_gb"] is Decimal
+```
+
+**Fix:**
+```python
+# Ensure usage_gb is float for arithmetic
+current_usage_gb = float(quota_status["usage_gb"]) if isinstance(quota_status["usage_gb"], Decimal) else quota_status["usage_gb"]
+projected_usage = current_usage_gb + file_size_gb
+```
+
+## Changes Made
+
+### 1. Added Import
+```python
+from decimal import Decimal
+```
+
+### 2. Type Conversion in `check_quota_exceeded()`
+- Convert `user_profile.echo_vault_quota_gb` from `Decimal` to `float` before arithmetic
+- Added null safety check
+
+### 3. Type Conversion in `can_upload()`
+- Check if `quota_status["usage_gb"]` is `Decimal` and convert to `float`
+- Safe handling for both `Decimal` and `float` types
+
+## Testing
+Created comprehensive test suite in `tests/test_storage_quota_decimal_fix.py`:
+
+1. **test_check_quota_handles_decimal_values**: Verifies quota checking with `Decimal` values from DynamoDB
+2. **test_can_upload_handles_decimal_values**: Verifies upload permission checking with `Decimal` values
+3. **test_can_upload_rejects_when_quota_exceeded_with_decimals**: Verifies rejection logic with `Decimal` values
+4. **test_check_quota_with_zero_quota**: Verifies zero division protection
+
+All tests pass ✅
+
+## Files Modified
+- `src/app/services/storage_quota_service.py` - Fixed type conversion issues
+- `tests/test_storage_quota_decimal_fix.py` - New test file with 4 comprehensive tests
+
+## Impact
+After deploying this fix:
+- ✅ Users can upload voice and video files to echo
+- ✅ Quota checking works correctly with DynamoDB `Decimal` values
+- ✅ No type errors during arithmetic operations
+- ✅ Proper handling of edge cases (zero quota, missing values)
+
+## Prevention
+To avoid similar issues in the future when working with DynamoDB:
+1. Always convert `Decimal` values to `float` before arithmetic operations
+2. Use `isinstance(value, Decimal)` checks when type is uncertain
+3. Add defensive null/zero checks for division operations
+4. Test with actual DynamoDB data (which uses `Decimal`) not just mock data
+
+## Related Documentation
+- Python Decimal documentation: https://docs.python.org/3/library/decimal.html
+- boto3 DynamoDB number handling: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/dynamodb.html#valid-dynamodb-types

--- a/src/app/services/echo_service.py
+++ b/src/app/services/echo_service.py
@@ -480,9 +480,18 @@ class EchoService:
             if not echo:
                 raise NotFoundError(f"Echo {echo_id} not found")
 
-            # Prevent updates to locked/released echoes (metadata only)
-            if echo.status != EchoStatus.DRAFT:
-                logger.warning(f"Attempted to update non-draft echo {echo_id}")
+            # Special case: Allow media attachment on RELEASED echoes (first-time only)
+            is_media_only_update = (
+                "media_url" in data
+                and set(data.keys()) <= {"media_url", "echo_type"}
+                and not echo.media_url  # Only if media_url is currently empty
+            )
+
+            # Prevent updates to locked/released echoes (except first-time media attachment)
+            if echo.status != EchoStatus.DRAFT and not is_media_only_update:
+                logger.warning(
+                    f"Attempted to update non-draft echo {echo_id} (status={echo.status.value})"
+                )
                 raise InternalServerError("Cannot update locked or released echo")
 
             # Apply updates
@@ -494,6 +503,14 @@ class EchoService:
                 echo.content = data["content"]
             if "media_url" in data:
                 echo.media_url = data["media_url"]
+                logger.info(
+                    f"Attached media to echo {echo_id} (status={echo.status.value})"
+                )
+            if "echo_type" in data:
+                try:
+                    echo.echo_type = EchoType(data["echo_type"])
+                except (ValueError, KeyError):
+                    pass  # Keep existing type if invalid
             if "recipient_id" in data:
                 echo.recipient_id = data["recipient_id"]
 

--- a/tests/test_echo_media_attachment.py
+++ b/tests/test_echo_media_attachment.py
@@ -1,0 +1,230 @@
+"""
+Test media attachment to RELEASED echoes.
+
+This tests the special case where media can be attached to a RELEASED echo
+as a first-time operation (e.g., after file upload completes).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.app.core.exceptions import InternalServerError
+from src.app.models.echo import Echo, EchoStatus, EchoType
+from src.app.services.echo_service import EchoService
+
+
+@pytest.mark.asyncio
+async def test_can_attach_media_to_released_echo():
+    """Test that media_url can be attached to a RELEASED echo (first-time only)."""
+    # Create a RELEASED echo without media
+    released_echo = Echo(
+        echo_id="echo-123",
+        user_id="user-456",
+        title="Test Echo",
+        status=EchoStatus.RELEASED,
+        media_url=None,  # No media attached yet
+        recipient_id="recipient-789",
+    )
+
+    # Create the service
+    echo_service = EchoService()
+
+    # Mock DynamoDB table
+    mock_table = AsyncMock()
+    mock_table.put_item = AsyncMock()
+    mock_dynamodb = AsyncMock()
+    mock_dynamodb.Table = AsyncMock(return_value=mock_table)
+
+    # Create async context manager for resource
+    mock_resource_ctx = MagicMock()
+    mock_resource_ctx.__aenter__ = AsyncMock(return_value=mock_dynamodb)
+    mock_resource_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    # Mock get_echo to return our released echo
+    with patch.object(
+        echo_service, "get_echo", new=AsyncMock(return_value=released_echo)
+    ):
+        with patch.object(
+            echo_service.session, "resource", return_value=mock_resource_ctx
+        ):
+            # Should allow attaching media to RELEASED echo
+            updated_echo = await echo_service.update_echo(
+                echo_id="echo-123",
+                user_id="user-456",
+                data={"media_url": "s3://bucket/user-456/echo-123.mp4"},
+            )
+
+            # Verify media was attached
+            assert updated_echo.media_url == "s3://bucket/user-456/echo-123.mp4"
+            assert updated_echo.status == EchoStatus.RELEASED
+            mock_table.put_item.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_can_attach_media_and_echo_type_to_released_echo():
+    """Test that media_url and echo_type can be updated together on RELEASED echo."""
+    released_echo = Echo(
+        echo_id="echo-123",
+        user_id="user-456",
+        title="Test Echo",
+        status=EchoStatus.RELEASED,
+        media_url=None,
+        echo_type=EchoType.TEXT,  # Initially text
+        recipient_id="recipient-789",
+    )
+
+    echo_service = EchoService()
+
+    mock_table = AsyncMock()
+    mock_table.put_item = AsyncMock()
+    mock_dynamodb = AsyncMock()
+    mock_dynamodb.Table = AsyncMock(return_value=mock_table)
+    mock_resource_ctx = MagicMock()
+    mock_resource_ctx.__aenter__ = AsyncMock(return_value=mock_dynamodb)
+    mock_resource_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(
+        echo_service, "get_echo", new=AsyncMock(return_value=released_echo)
+    ):
+        with patch.object(
+            echo_service.session, "resource", return_value=mock_resource_ctx
+        ):
+            # Should allow attaching media + changing type
+            updated_echo = await echo_service.update_echo(
+                echo_id="echo-123",
+                user_id="user-456",
+                data={
+                    "media_url": "s3://bucket/user-456/echo-123.mp4",
+                    "echo_type": "VIDEO",
+                },
+            )
+
+            assert updated_echo.media_url == "s3://bucket/user-456/echo-123.mp4"
+            assert updated_echo.echo_type == EchoType.VIDEO
+            mock_table.put_item.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cannot_update_other_fields_on_released_echo():
+    """Test that non-media fields cannot be updated on RELEASED echo."""
+    released_echo = Echo(
+        echo_id="echo-123",
+        user_id="user-456",
+        title="Original Title",
+        status=EchoStatus.RELEASED,
+        media_url=None,
+        recipient_id="recipient-789",
+    )
+
+    echo_service = EchoService()
+
+    with patch.object(
+        echo_service, "get_echo", new=AsyncMock(return_value=released_echo)
+    ):
+        # Should reject updates to title on RELEASED echo
+        with pytest.raises(
+            InternalServerError, match="Cannot update locked or released"
+        ):
+            await echo_service.update_echo(
+                echo_id="echo-123",
+                user_id="user-456",
+                data={"title": "New Title"},
+            )
+
+
+@pytest.mark.asyncio
+async def test_cannot_attach_media_twice():
+    """Test that media cannot be replaced on a RELEASED echo that already has media."""
+    released_echo = Echo(
+        echo_id="echo-123",
+        user_id="user-456",
+        title="Test Echo",
+        status=EchoStatus.RELEASED,
+        media_url="s3://bucket/user-456/original.mp4",  # Already has media
+        recipient_id="recipient-789",
+    )
+
+    echo_service = EchoService()
+
+    with patch.object(
+        echo_service, "get_echo", new=AsyncMock(return_value=released_echo)
+    ):
+        # Should reject replacing existing media
+        with pytest.raises(
+            InternalServerError, match="Cannot update locked or released"
+        ):
+            await echo_service.update_echo(
+                echo_id="echo-123",
+                user_id="user-456",
+                data={"media_url": "s3://bucket/user-456/new.mp4"},
+            )
+
+
+@pytest.mark.asyncio
+async def test_cannot_update_media_with_other_fields_on_released_echo():
+    """Test that media + other field updates are rejected on RELEASED echo."""
+    released_echo = Echo(
+        echo_id="echo-123",
+        user_id="user-456",
+        title="Original Title",
+        status=EchoStatus.RELEASED,
+        media_url=None,
+        recipient_id="recipient-789",
+    )
+
+    echo_service = EchoService()
+
+    with patch.object(
+        echo_service, "get_echo", new=AsyncMock(return_value=released_echo)
+    ):
+        # Should reject media + title update together
+        with pytest.raises(
+            InternalServerError, match="Cannot update locked or released"
+        ):
+            await echo_service.update_echo(
+                echo_id="echo-123",
+                user_id="user-456",
+                data={
+                    "media_url": "s3://bucket/user-456/echo-123.mp4",
+                    "title": "New Title",
+                },
+            )
+
+
+@pytest.mark.asyncio
+async def test_draft_echo_can_be_updated_freely():
+    """Test that DRAFT echoes can still be updated normally."""
+    draft_echo = Echo(
+        echo_id="echo-123",
+        user_id="user-456",
+        title="Original Title",
+        status=EchoStatus.DRAFT,
+        media_url=None,
+    )
+
+    echo_service = EchoService()
+
+    mock_table = AsyncMock()
+    mock_table.put_item = AsyncMock()
+    mock_dynamodb = AsyncMock()
+    mock_dynamodb.Table = AsyncMock(return_value=mock_table)
+    mock_resource_ctx = MagicMock()
+    mock_resource_ctx.__aenter__ = AsyncMock(return_value=mock_dynamodb)
+    mock_resource_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(echo_service, "get_echo", new=AsyncMock(return_value=draft_echo)):
+        with patch.object(
+            echo_service.session, "resource", return_value=mock_resource_ctx
+        ):
+            # Should allow updating title on DRAFT echo
+            updated_echo = await echo_service.update_echo(
+                echo_id="echo-123",
+                user_id="user-456",
+                data={"title": "New Title", "content": "New content"},
+            )
+
+            assert updated_echo.title == "New Title"
+            assert updated_echo.content == "New content"
+            assert updated_echo.status == EchoStatus.DRAFT
+            mock_table.put_item.assert_called_once()


### PR DESCRIPTION
…oad)

- Allow first-time media_url attachment on RELEASED echoes
- Restrict to media_url + echo_type fields only
- Prevent replacing existing media (security)
- Add 6 comprehensive tests (all passing)
- Resolves issue where videos not attaching to echoes

The workflow now allows:
1. Create echo with recipient (auto-released)
2. Upload media to S3
3. PATCH echo with media_url (now succeeds)

Related to previous fixes:
- Recipient access control
- Storage quota Decimal handling