### PR TITLE
feat: add profile image upload support for recipients, guardians, and…

### DIFF
--- a/src/app/api/echo_routes.py
+++ b/src/app/api/echo_routes.py
@@ -73,8 +73,12 @@ class UpdateEchoRequest(BaseModel):
 
 
 class UploadUrlRequest(BaseModel):
-    file_type: str  # MIME type: audio/mp4, video/mp4
+    file_type: str  # MIME type: audio/mp4, video/mp4, image/jpeg
     echo_id: Optional[str] = None
+    # 'echo' → echoes/{user_id}/ path
+    # 'profile' → profiles/{user_id}/ path (recipient / guardian photo)
+    # 'user_profile' → user_profiles/{user_id}/ path (own avatar)
+    upload_type: Optional[str] = "echo"
 
 
 class CreateRecipientRequest(BaseModel):
@@ -82,6 +86,7 @@ class CreateRecipientRequest(BaseModel):
     email: EmailStr
     relationship: Optional[str] = None
     motif: Optional[str] = None
+    profile_image_url: Optional[str] = None  # S3 URL returned by upload-url flow
 
 
 class CreateGuardianRequest(BaseModel):
@@ -89,6 +94,7 @@ class CreateGuardianRequest(BaseModel):
     email: EmailStr
     scope: str = "ALL"  # ALL, SELECTED
     trigger: str = "MANUAL"  # MANUAL, AUTOMATIC
+    profile_image_url: Optional[str] = None  # S3 URL returned by upload-url flow
 
 
 class UpdateGuardianPermissionsRequest(BaseModel):
@@ -173,6 +179,7 @@ async def get_upload_url(
         user_id=user_id,
         file_type=request.file_type,
         echo_id=request.echo_id,
+        upload_type=request.upload_type or "echo",
     )
 
     return {
@@ -445,6 +452,7 @@ async def list_recipients(
                 "email": r.email,
                 "relationship": r.relationship,
                 "motif": r.motif,
+                "profile_image_url": r.profile_image_url,
                 "created_at": r.created_at,
             }
             for r in recipients
@@ -481,6 +489,7 @@ async def create_recipient(
             "name": recipient.name,
             "email": recipient.email,
             "motif": recipient.motif,
+            "profile_image_url": recipient.profile_image_url,
         },
         "message": "Recipient added successfully",
     }
@@ -528,6 +537,7 @@ async def list_guardians(
                 "email": g.email,
                 "scope": g.scope.value,
                 "trigger": g.trigger.value,
+                "profile_image_url": g.profile_image_url,
                 "created_at": g.created_at,
             }
             for g in guardians
@@ -566,6 +576,7 @@ async def create_guardian(
             "email": guardian.email,
             "scope": guardian.scope.value,
             "trigger": guardian.trigger.value,
+            "profile_image_url": guardian.profile_image_url,
         },
         "message": "Guardian added successfully",
     }

--- a/src/app/api/routes.py
+++ b/src/app/api/routes.py
@@ -1,13 +1,15 @@
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 
 from ..controllers.auth_controller import AuthController
 from ..core.enhanced_auth import get_user_with_profile
 from ..core.security import get_current_user
 from ..services.dynamodb_service import DynamoDBService
 from ..services.sns_service import SNSService
+from ..services.user_service import UserService
 from .models import (
     AuthResponse,
     DeviceRegistrationRequest,
@@ -32,6 +34,11 @@ router = APIRouter()
 auth_controller = AuthController()
 sns_service = SNSService()
 dynamodb_service = DynamoDBService()
+user_service = UserService()
+
+
+class UpdateProfileRequest(BaseModel):
+    profile_image_url: Optional[str] = None
 
 
 # Dependency injection for controllers
@@ -100,8 +107,42 @@ async def get_current_user_profile(
     current_user: Dict[str, Any] = Depends(get_user_with_profile),
     auth_controller=Depends(get_auth_controller),
 ):
-    """Get current authenticated user profile"""
+    """Get current authenticated user profile (Cognito attrs + DynamoDB extras)."""
+    user_id = current_user.get("id") or current_user.get("sub", "")
+    # Merge DynamoDB profile extras (profile_image_url, preferences, etc.) on top
+    if user_id:
+        try:
+            db_profile = await user_service.get_user_profile(user_id)
+            if db_profile and db_profile.profile_image_url:
+                current_user = {
+                    **current_user,
+                    "profile_image_url": db_profile.profile_image_url,
+                }
+        except Exception as e:
+            logger.warning(f"Could not fetch DynamoDB profile for /auth/me: {e}")
     return await auth_controller.get_current_user_profile(current_user)
+
+
+@router.patch("/auth/me")
+async def update_current_user_profile(
+    request: UpdateProfileRequest,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """Update the current user's profile (e.g. save uploaded profile_image_url)."""
+    user_id = current_user.get("id") or current_user.get("sub", "")
+    if not user_id:
+        raise HTTPException(status_code=400, detail="User ID not found in token")
+
+    updates = request.model_dump(exclude_none=True)
+    if not updates:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    try:
+        await user_service.update_user_profile(user_id, updates)
+        return {"success": True, "message": "Profile updated successfully"}
+    except Exception as e:
+        logger.error(f"Failed to update profile for {user_id}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to update profile")
 
 
 @router.post("/auth/logout", response_model=GeneralApiResponse)

--- a/src/app/models/echo.py
+++ b/src/app/models/echo.py
@@ -154,6 +154,7 @@ class Recipient:
     # Optional metadata
     motif: Optional[str] = None  # Personal motif/symbol
     relationship: Optional[str] = None  # e.g., "Family", "Friend", "Work"
+    profile_image_url: Optional[str] = None  # S3 URL of uploaded profile photo
 
     # Timestamps
     created_at: str = field(default_factory=_current_timestamp)
@@ -192,6 +193,9 @@ class Guardian:
     # Contact info
     name: str = ""
     email: str = ""
+
+    # Optional profile photo
+    profile_image_url: Optional[str] = None  # S3 URL of uploaded profile photo
 
     # Permissions
     scope: GuardianScope = GuardianScope.ALL

--- a/src/app/models/user_profile.py
+++ b/src/app/models/user_profile.py
@@ -71,6 +71,9 @@ class UserProfile:
     storage_subscription_id: Optional[str] = None  # Reference to storage add-on
     last_subscription_check: Optional[str] = None  # ISO 8601
 
+    # Profile photo (S3 URL uploaded via /api/echoes/upload-url with upload_type='user_profile')
+    profile_image_url: Optional[str] = None
+
     # Timestamps
     created_at: Optional[str] = None
     updated_at: Optional[str] = None

--- a/src/app/services/echo_service.py
+++ b/src/app/services/echo_service.py
@@ -279,6 +279,7 @@ class EchoService:
                             "name": recipient.name,
                             "email": recipient.email,
                             "motif": recipient.motif,
+                            "profile_image_url": recipient.profile_image_url,
                         }
 
                 return echo
@@ -351,6 +352,7 @@ class EchoService:
                                     "name": recipient.name,
                                     "email": recipient.email,
                                     "motif": recipient.motif,
+                                    "profile_image_url": recipient.profile_image_url,
                                 }
 
                         echo.recipient = recipient_cache.get(echo.recipient_id)
@@ -735,29 +737,48 @@ class EchoService:
         user_id: str,
         file_type: str,
         echo_id: Optional[str] = None,
+        upload_type: str = "echo",
     ) -> Dict[str, Any]:
         """
         Generate S3 presigned URL for direct upload.
 
         Args:
             user_id: User ID
-            file_type: MIME type (e.g., "audio/mp4", "video/mp4")
-            echo_id: Optional echo ID (if updating existing)
+            file_type: MIME type (e.g., "audio/mp4", "video/mp4", "image/jpeg")
+            echo_id: Optional echo ID (required for upload_type='echo')
+            upload_type: 'echo' | 'profile' | 'user_profile'
+                - 'echo': echoes/{user_id}/{echo_id}_{ts}.ext
+                - 'profile': profiles/{user_id}/{ts}.ext  (recipient / guardian photo)
+                - 'user_profile': user_profiles/{user_id}/{ts}.ext  (own avatar)
 
         Returns:
-            Dict with 'upload_url' and 'key'
+            Dict with 'upload_url', 'media_url', 'key', 'bucket', 'expires_in'
         """
         try:
-            # Determine file extension from type
-            extension = "mp4"  # Default
+            # Determine file extension from MIME type
+            extension = "mp4"  # default for video
             if "audio" in file_type:
                 extension = "m4a"
             elif "video" in file_type:
                 extension = "mp4"
+            elif "image" in file_type:
+                ext_map = {
+                    "image/jpeg": "jpg",
+                    "image/png": "png",
+                    "image/webp": "webp",
+                    "image/heic": "heic",
+                }
+                extension = ext_map.get(file_type, "jpg")
 
-            # Generate unique key
             timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-            key = f"echoes/{user_id}/{echo_id or 'new'}_{timestamp}.{extension}"
+
+            if upload_type == "profile":
+                key = f"profiles/{user_id}/{timestamp}.{extension}"
+            elif upload_type == "user_profile":
+                key = f"user_profiles/{user_id}/{timestamp}.{extension}"
+            else:
+                # echo — echo_id may be None for new echoes
+                key = f"echoes/{user_id}/{echo_id or 'new'}_{timestamp}.{extension}"
 
             async with self.session.client("s3", region_name=self.region) as s3:
                 presigned_url = await s3.generate_presigned_url(
@@ -864,6 +885,7 @@ class EchoService:
                     recipient_user_id=recipient_user_id,
                     relationship=data.get("relationship"),
                     motif=data.get("motif"),
+                    profile_image_url=data.get("profile_image_url"),
                 )
 
                 logger.info(
@@ -1012,6 +1034,7 @@ class EchoService:
                     email=email,
                     scope=GuardianScope(data.get("scope", "ALL")),
                     trigger=GuardianTrigger(data.get("trigger", "MANUAL")),
+                    profile_image_url=data.get("profile_image_url"),
                 )
 
                 await table.put_item(Item=guardian.to_dynamodb_item())


### PR DESCRIPTION
… users

echo_routes.py:
- UploadUrlRequest: add upload_type ('echo'|'profile'|'user_profile')
- CreateRecipientRequest + CreateGuardianRequest: add profile_image_url field
- list_recipients, create_recipient, list_guardians, create_guardian responses now include profile_image_url

echo_service.py:
- generate_upload_url: accept upload_type, handle image/* extensions, route to separate S3 paths per type (echoes/, profiles/, user_profiles/)
- create_recipient / create_guardian: persist profile_image_url
- get_user_echoes / get_echo recipient enrichment: include profile_image_url

models/echo.py:
- Recipient + Guardian dataclasses: add profile_image_url field

models/user_profile.py:
- UserProfile: add profile_image_url field

routes.py:
- GET /auth/me: merge DynamoDB profile_image_url into Cognito-derived response
- PATCH /auth/me: new endpoint to save user's own uploaded avatar URL