### PR TITLE
fix: generate presigned GET URLs for profile images (S3 bucket is pri…

### DIFF
--- a/src/app/api/routes.py
+++ b/src/app/api/routes.py
@@ -8,6 +8,7 @@ from ..controllers.auth_controller import AuthController
 from ..core.enhanced_auth import get_user_with_profile
 from ..core.security import get_current_user
 from ..services.dynamodb_service import DynamoDBService
+from ..services.echo_service import EchoService
 from ..services.sns_service import SNSService
 from ..services.user_service import UserService
 from .models import (
@@ -35,6 +36,7 @@ auth_controller = AuthController()
 sns_service = SNSService()
 dynamodb_service = DynamoDBService()
 user_service = UserService()
+echo_service = EchoService()
 
 
 class UpdateProfileRequest(BaseModel):
@@ -114,9 +116,12 @@ async def get_current_user_profile(
         try:
             db_profile = await user_service.get_user_profile(user_id)
             if db_profile and db_profile.profile_image_url:
+                signed_url = await echo_service._sign_profile_url(
+                    db_profile.profile_image_url
+                )
                 current_user = {
                     **current_user,
-                    "profile_image_url": db_profile.profile_image_url,
+                    "profile_image_url": signed_url,
                 }
         except Exception as e:
             logger.warning(f"Could not fetch DynamoDB profile for /auth/me: {e}")

--- a/src/app/services/echo_service.py
+++ b/src/app/services/echo_service.py
@@ -279,7 +279,9 @@ class EchoService:
                             "name": recipient.name,
                             "email": recipient.email,
                             "motif": recipient.motif,
-                            "profile_image_url": recipient.profile_image_url,
+                            "profile_image_url": await self._sign_profile_url(
+                                recipient.profile_image_url
+                            ),
                         }
 
                 return echo
@@ -352,7 +354,9 @@ class EchoService:
                                     "name": recipient.name,
                                     "email": recipient.email,
                                     "motif": recipient.motif,
-                                    "profile_image_url": recipient.profile_image_url,
+                                    "profile_image_url": await self._sign_profile_url(
+                                        recipient.profile_image_url
+                                    ),
                                 }
 
                         echo.recipient = recipient_cache.get(echo.recipient_id)
@@ -806,6 +810,28 @@ class EchoService:
             logger.error(f"S3 error generating presigned URL: {e}")
             raise InternalServerError(f"Failed to generate upload URL: {str(e)}")
 
+    async def _sign_profile_url(self, url: Optional[str]) -> Optional[str]:
+        """Generate presigned GET URL for a profile/avatar image stored in S3.
+
+        Profile images live in the same private bucket as echo media.
+        TTL is 12 hours — the maximum safe value for Lambda IAM role sessions.
+        Called on every list/get request so the URL is always fresh.
+        """
+        if not url or "amazonaws.com" not in url:
+            return url
+        try:
+            key = url.split("amazonaws.com/")[-1]
+            async with self.session.client("s3", region_name=self.region) as s3:
+                presigned = await s3.generate_presigned_url(
+                    "get_object",
+                    Params={"Bucket": self.s3_bucket, "Key": key},
+                    ExpiresIn=43200,  # 12 h — max for temporary Lambda credentials
+                )
+            return presigned
+        except Exception as e:
+            logger.error(f"Failed to sign profile URL: {e}")
+            return url  # Return original on error; image will 403 but app won't crash
+
     async def _sign_media_url(self, echo: Echo) -> Echo:
         """Generate presigned GET URL for secure media playback."""
         if echo.media_url and "amazonaws.com" in echo.media_url:
@@ -935,6 +961,9 @@ class EchoService:
                 for item in response.get("Items", []):
                     recipient = Recipient.from_dynamodb_item(item)
                     if recipient.deleted_at is None:
+                        recipient.profile_image_url = await self._sign_profile_url(
+                            recipient.profile_image_url
+                        )
                         recipients.append(recipient)
 
                 return recipients
@@ -1066,6 +1095,9 @@ class EchoService:
                 for item in response.get("Items", []):
                     guardian = Guardian.from_dynamodb_item(item)
                     if guardian.deleted_at is None:
+                        guardian.profile_image_url = await self._sign_profile_url(
+                            guardian.profile_image_url
+                        )
                         guardians.append(guardian)
 
                 return guardians


### PR DESCRIPTION
…vate)

The echo-vault S3 bucket has no public-read policy, so static media_url strings return 403. Profile images (recipients, guardians, user avatar) now get a presigned GET URL (12h TTL) on every API response — the same pattern already used for echo audio/video via _sign_media_url.

- _sign_profile_url(): new helper, 43200s TTL (max for Lambda IAM sessions)
- get_user_recipients: sign profile_image_url per recipient
- get_user_guardians: sign profile_image_url per guardian
- get_user_echoes / get_echo: sign profile_image_url in recipient enrichment
- GET /auth/me: sign user profile_image_url from DynamoDB