### PR TITLE
fix: add types-PyYAML and prune unused mypy overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,14 +38,6 @@ disallow_untyped_defs = false
 module = "src.app.services.cognito_service"
 ignore_errors = true
 
-[[tool.mypy.overrides]]
-module = "performance_analysis"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
-module = "scripts.*"
-ignore_errors = true
-
 # Reflection Room V1: Pydantic v1-style confloat/conint runtime validators
 # resolve correctly at runtime but trip mypy's valid-type check. Pydantic v2
 # rewriting (Annotated[float, Field(...)]) is a follow-up — not blocking V1.
@@ -71,12 +63,6 @@ ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = "src.app.api.practice_routes"
-ignore_errors = true
-
-# Test files: heavy use of dynamic **dict patterns mypy can't narrow.
-# Matches the scripts.* precedent above.
-[[tool.mypy.overrides]]
-module = "tests.*"
 ignore_errors = true
 
 [tool.pytest.ini_options]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,4 @@ bandit[toml]>=1.7.5
 safety>=3.0.0
 httpx>=0.25.0  # For testing HTTP requests
 pytest-mock>=3.12.0
+types-PyYAML>=6.0.0  # mypy stubs for YAML loaders (Reflection Room V1)


### PR DESCRIPTION
CI mypy run was failing on src/app:
- error: Library stubs not installed for "yaml" — adds types-PyYAML to requirements-dev.txt so the YAML loaders type-check cleanly
- warn_unused_configs flagged 3 overrides that didn't match any module in the CI's check scope (88 src/app/* files): performance_analysis (top-level file), scripts.* (out of scope), and tests.* (out of scope). Removed all three; the remaining cognito_service + 6 Reflection Room overrides are load-bearing.

Local mypy: Success: no issues found in 88 source files
Suite: 475 passed (no regressions)