### PR TITLE
fix: query echo inbox by recipient_user_id instead of email

### DIFF
--- a/scripts/backfill_recipient_user_id.py
+++ b/scripts/backfill_recipient_user_id.py
@@ -1,0 +1,170 @@
+"""Backfill recipient_user_id on legacy recipient rows.
+
+For every recipient row in DynamoDB where recipient_user_id is missing or empty,
+look up the email in the users table; if a UserProfile exists for that email,
+patch recipient_user_id to the user's Cognito sub.
+
+This is needed because:
+
+1. recipient_user_id is only set at recipient-creation time (echo_service.create_recipient).
+2. Recipients added before the recipient signed up have recipient_user_id = None.
+3. The inbox query keys off recipient-user-id-index, so unlinked rows are invisible.
+
+The signup flow now back-links new users automatically (auth_controller.confirm_email),
+but historical rows need this one-shot script.
+
+Usage (from repo root):
+    AWS_PROFILE=... python scripts/backfill_recipient_user_id.py
+    AWS_PROFILE=... python scripts/backfill_recipient_user_id.py --dry-run
+
+Environment variables (read from src.app.services config — same as the API):
+    DYNAMODB_RECIPIENTS_TABLE
+    DYNAMODB_USERS_TABLE
+    AWS_REGION
+
+Idempotent: rerunning is safe. Rows already linked are skipped.
+
+Exit codes:
+    0  Completed (with summary)
+    1  Fatal error before scan finished
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+
+# Ensure we can import src.app.* when run from repo root.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger("backfill_recipient_user_id")
+
+
+async def _run(dry_run: bool) -> int:
+    from src.app.models.echo import _current_timestamp  # type: ignore
+    from src.app.services.dynamodb_service import DynamoDBService
+    from src.app.services.echo_service import EchoService
+
+    echo_service = EchoService()
+    dynamodb_service = DynamoDBService()
+
+    scanned = 0
+    already_linked = 0
+    linked = 0
+    no_user = 0
+    deleted_skipped = 0
+    errors = 0
+
+    async with echo_service.session.resource(
+        "dynamodb", **echo_service._get_dynamodb_kwargs()
+    ) as dynamodb:
+        table = await dynamodb.Table(echo_service.recipients_table)
+
+        scan_kwargs: dict = {}
+        while True:
+            response = await table.scan(**scan_kwargs)
+            for item in response.get("Items", []):
+                scanned += 1
+
+                if item.get("deleted_at") is not None:
+                    deleted_skipped += 1
+                    continue
+
+                if item.get("recipient_user_id"):
+                    already_linked += 1
+                    continue
+
+                email = (item.get("email") or "").strip().lower()
+                if not email:
+                    no_user += 1
+                    continue
+
+                try:
+                    user = await dynamodb_service.get_user_by_email(email)
+                except Exception as e:  # noqa: BLE001
+                    errors += 1
+                    logger.error(
+                        f"get_user_by_email failed for {email} "
+                        f"(recipient {item.get('recipient_id')}): {e}"
+                    )
+                    continue
+
+                if not user:
+                    no_user += 1
+                    continue
+
+                user_id = user.user_id
+                recipient_id = item["recipient_id"]
+
+                if dry_run:
+                    logger.info(
+                        f"[dry-run] would link recipient {recipient_id} "
+                        f"({email}) -> user {user_id}"
+                    )
+                    linked += 1
+                    continue
+
+                try:
+                    await table.update_item(
+                        Key={"recipient_id": recipient_id},
+                        UpdateExpression=(
+                            "SET recipient_user_id = :uid, updated_at = :ts"
+                        ),
+                        ExpressionAttributeValues={
+                            ":uid": user_id,
+                            ":ts": _current_timestamp(),
+                        },
+                    )
+                    linked += 1
+                    logger.info(
+                        f"linked recipient {recipient_id} ({email}) -> "
+                        f"user {user_id}"
+                    )
+                except Exception as e:  # noqa: BLE001
+                    errors += 1
+                    logger.error(
+                        f"update_item failed for recipient {recipient_id}: {e}"
+                    )
+
+            last_key = response.get("LastEvaluatedKey")
+            if not last_key:
+                break
+            scan_kwargs["ExclusiveStartKey"] = last_key
+
+    logger.info("---- Backfill summary ----")
+    logger.info(f"scanned          : {scanned}")
+    logger.info(f"already linked   : {already_linked}")
+    logger.info(f"newly linked     : {linked}{' (dry-run)' if dry_run else ''}")
+    logger.info(f"no matching user : {no_user}")
+    logger.info(f"deleted skipped  : {deleted_skipped}")
+    logger.info(f"errors           : {errors}")
+    return 0 if errors == 0 else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be linked without writing.",
+    )
+    args = parser.parse_args()
+
+    try:
+        return asyncio.run(_run(dry_run=args.dry_run))
+    except KeyboardInterrupt:
+        logger.warning("Interrupted")
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/app/api/echo_routes.py
+++ b/src/app/api/echo_routes.py
@@ -233,19 +233,18 @@ async def list_received_echoes(
     sender_id: Optional[str] = Query(None, description="Filter by sender"),
     current_user: Dict[str, Any] = Depends(get_current_user),
 ):
-    """List echoes received by the current user (inbox view)."""
-    user_id = current_user.get("id", "")
-    user_email = current_user.get("email", "")
+    """List echoes received by the current user (inbox view).
 
-    if not user_id and not user_email:
-        raise HTTPException(
-            status_code=400, detail="User ID or email not found in token"
-        )
+    Recipient match is by Cognito sub via recipients.recipient-user-id-index,
+    which is populated at recipient creation and back-filled when the recipient
+    later signs up. No email lookup is needed.
+    """
+    user_id = current_user.get("id") or ""
+    if not user_id:
+        raise HTTPException(status_code=400, detail="User ID not found in token")
 
-    # Prefer user_id matching, fallback to email
     echoes = await echo_service.get_received_echoes(
-        user_id=user_id if user_id else None,
-        recipient_email=user_email if user_email else None,
+        user_id=user_id,
         category=category,
         sender_id=sender_id,
     )

--- a/src/app/controllers/auth_controller.py
+++ b/src/app/controllers/auth_controller.py
@@ -21,6 +21,7 @@ from ..api.models import (
 )
 from ..services.cognito_service import CognitoService
 from ..services.dynamodb_service import DynamoDBService
+from ..services.echo_service import EchoService
 from ..services.user_linking_service import UserLinkingService
 from ..services.user_service import UserService
 
@@ -35,6 +36,7 @@ class AuthController:
         self.user_service = UserService()
         self.dynamodb_service = DynamoDBService()
         self.linking_service = UserLinkingService(self.dynamodb_service)
+        self.echo_service = EchoService()
 
     async def register(self, payload: UserRegistrationRequest) -> AuthResponse:
         """Register a new user account"""
@@ -250,6 +252,22 @@ class AuthController:
                     except Exception as link_error:
                         logger.error(f"Failed to link anonymous data: {link_error}")
                         # Don't fail email confirmation if linking fails
+
+                # Back-link recipient rows that other users created with this
+                # email before this user signed up. Without this, their inbox
+                # is silent because the recipient row's recipient_user_id is None.
+                try:
+                    await self.echo_service.link_user_to_recipients(
+                        user_id=user_profile.user_id,
+                        email=user_profile.email,
+                    )
+                except Exception as backlink_error:
+                    logger.error(
+                        f"Failed to back-link recipients for "
+                        f"{user_profile.user_id}: {backlink_error}"
+                    )
+                    # Don't fail confirmation; the offline backfill script
+                    # (scripts/backfill_recipient_user_id.py) will recover.
 
             except Exception as e:
                 # Log the error but don't fail the email confirmation

--- a/src/app/core/security.py
+++ b/src/app/core/security.py
@@ -80,25 +80,21 @@ def map_claims_to_profile(payload: Dict[str, Any]) -> Dict[str, Any]:
 
     groups: List[str] = payload.get("cognito:groups", []) or []
 
-    # Try multiple ways to get email
+    # Email comes only from the 'email' claim. Cognito ACCESS tokens do not
+    # carry it; ID tokens do. Do NOT fall back to sub/username here — that
+    # produced a UUID-shaped string in profile["email"] and silently broke
+    # downstream lookups (e.g. inbox match by email). Callers that need the
+    # email when only an access token was sent must resolve it from the users
+    # table by sub.
     email = payload.get("email")
-    if not email:
-        email = payload.get("cognito:username")
-    if not email:
-        email = payload.get("username")
-    if not email:
-        email = None
 
-    # If we still don't have email and this is an access token, warn about it
     token_use = payload.get("token_use")
-    if (
-        not email and token_use == "access"  # nosec B105
-    ):  # 'access' is a token type, not a password
+    if not email and token_use == "access":  # nosec B105 — 'access' is a token type
         logger.warning(
-            "⚠️  No email found in access token. "
-            "Consider using ID token for user profile endpoints."
+            "⚠️  No email claim in access token. "
+            "Endpoints that need the user's email must resolve it via the "
+            "users table by sub. Available claims: " + ", ".join(payload.keys())
         )
-        logger.info("💡 Available claims in access token: " + ", ".join(payload.keys()))
 
     logger.info(f"🔍 Extracted email from payload: {email}")
 

--- a/src/app/services/echo_service.py
+++ b/src/app/services/echo_service.py
@@ -369,55 +369,57 @@ class EchoService:
 
     async def get_received_echoes(
         self,
-        user_id: Optional[str] = None,
-        recipient_email: Optional[str] = None,
+        user_id: str,
         category: Optional[str] = None,
         sender_id: Optional[str] = None,
     ) -> List[Echo]:
         """
         Get echoes received by a user (inbox view).
         Only returns RELEASED echoes.
-        Prefers user_id matching (more reliable), falls back to email matching.
+
+        Matches recipient rows by recipient_user_id (Cognito sub) via the
+        recipient-user-id-index GSI. This is authoritative and works regardless
+        of whether the JWT carries an email claim. Recipient rows added before
+        the recipient signed up are back-linked at confirmation time (see
+        echo_service.link_user_recipient_records) and via the offline backfill
+        script in scripts/backfill_recipient_user_id.py.
 
         Args:
-            user_id: Logged-in user's Cognito sub (preferred)
-            recipient_email: Logged-in user's email (fallback)
+            user_id: Logged-in user's Cognito sub
             category: Filter by category
             sender_id: Filter by sender
 
         Returns:
             List of received echoes
         """
-        try:
-            recipient_ids = []
+        if not user_id:
+            raise ValidationError("user_id is required for inbox lookup")
 
+        try:
             async with self.session.resource(
                 "dynamodb", **self._get_dynamodb_kwargs()
             ) as dynamodb:
                 recipients_table = await dynamodb.Table(self.recipients_table)
 
-                # Look up recipient records whose email matches the logged-in user.
-                # The recipients table has an email-index GSI (hash key: email).
-                if recipient_email:
-                    recipient_response = await recipients_table.query(
-                        IndexName="email-index",
-                        KeyConditionExpression="email = :email",
-                        ExpressionAttributeValues={":email": recipient_email.lower()},
-                    )
-                    recipient_ids = [
-                        item["recipient_id"]
-                        for item in recipient_response.get("Items", [])
-                    ]
-                    if recipient_ids:
-                        logger.info(
-                            f"Found {len(recipient_ids)} recipient records for email: {recipient_email}"
-                        )
+                recipient_response = await recipients_table.query(
+                    IndexName="recipient-user-id-index",
+                    KeyConditionExpression="recipient_user_id = :uid",
+                    ExpressionAttributeValues={":uid": user_id},
+                )
+                recipient_items = [
+                    item
+                    for item in recipient_response.get("Items", [])
+                    if item.get("deleted_at") is None
+                ]
+                recipient_ids = [item["recipient_id"] for item in recipient_items]
 
                 if not recipient_ids:
-                    logger.info(
-                        f"No recipient records found for user {user_id} / {recipient_email}"
-                    )
+                    logger.info(f"Inbox: no recipient records linked to user {user_id}")
                     return []
+
+                logger.info(
+                    f"Inbox: found {len(recipient_ids)} recipient records for user {user_id}"
+                )
 
                 # Query released echoes for each matched recipient.
                 # recipient-echoes-index: hash=recipient_id, sort=status — use both
@@ -928,6 +930,92 @@ class EchoService:
         except Exception as e:
             logger.error(f"Error creating recipient: {e}")
             raise InternalServerError(f"Failed to create recipient: {str(e)}")
+
+    async def link_user_to_recipients(self, user_id: str, email: str) -> int:
+        """
+        Back-link a newly-confirmed user to existing recipient rows whose
+        email matches.
+
+        Called from the signup-confirmation flow so that recipients added
+        BEFORE the recipient signed up become discoverable via the
+        recipient-user-id-index GSI used by the inbox query.
+
+        Idempotent: rows already linked to this user_id are skipped; rows
+        linked to a different user_id are left alone and logged.
+
+        Args:
+            user_id: New user's Cognito sub.
+            email: New user's email (case-insensitive).
+
+        Returns:
+            Number of recipient rows newly linked.
+        """
+        if not user_id or not email:
+            return 0
+
+        normalized_email = email.strip().lower()
+        if not normalized_email:
+            return 0
+
+        linked = 0
+        try:
+            async with self.session.resource(
+                "dynamodb", **self._get_dynamodb_kwargs()
+            ) as dynamodb:
+                table = await dynamodb.Table(self.recipients_table)
+
+                response = await table.query(
+                    IndexName="email-index",
+                    KeyConditionExpression="email = :email",
+                    ExpressionAttributeValues={":email": normalized_email},
+                )
+
+                for item in response.get("Items", []):
+                    if item.get("deleted_at") is not None:
+                        continue
+
+                    existing = item.get("recipient_user_id")
+                    if existing == user_id:
+                        continue
+                    if existing and existing != user_id:
+                        logger.warning(
+                            f"Recipient {item.get('recipient_id')} already linked to "
+                            f"a different user_id ({existing}); skipping back-link "
+                            f"for {user_id}"
+                        )
+                        continue
+
+                    await table.update_item(
+                        Key={"recipient_id": item["recipient_id"]},
+                        UpdateExpression="SET recipient_user_id = :uid, updated_at = :ts",
+                        ExpressionAttributeValues={
+                            ":uid": user_id,
+                            ":ts": _current_timestamp(),
+                        },
+                    )
+                    linked += 1
+                    logger.info(
+                        f"Back-linked recipient {item.get('recipient_id')} "
+                        f"(email={normalized_email}) to user {user_id}"
+                    )
+
+            if linked:
+                logger.info(
+                    f"link_user_to_recipients: linked {linked} recipient row(s) "
+                    f"for user {user_id} ({normalized_email})"
+                )
+            else:
+                logger.info(
+                    f"link_user_to_recipients: no recipient rows to link for "
+                    f"user {user_id} ({normalized_email})"
+                )
+            return linked
+
+        except ClientError as e:
+            # Don't fail the signup confirmation if back-link fails — log and
+            # rely on the offline backfill script to recover.
+            logger.error(f"link_user_to_recipients failed for user {user_id}: {e}")
+            return linked
 
     async def get_user_recipients(self, user_id: str) -> List[Recipient]:
         """Get all active recipients for a user (excluding soft-deleted)."""

--- a/tests/test_echo_vault.py
+++ b/tests/test_echo_vault.py
@@ -1590,8 +1590,8 @@ class TestRecipientUserIdLinking:
         assert "recipient_user_id" not in captured_items[0]
 
     @pytest.mark.asyncio
-    async def test_get_received_echoes_uses_email_index(self):
-        """get_received_echoes should look up recipients by email-index (single strategy)."""
+    async def test_get_received_echoes_uses_recipient_user_id_index(self):
+        """get_received_echoes should look up recipients by recipient-user-id-index."""
         from src.app.models.echo import EchoStatus
         from src.app.services.echo_service import EchoService
 
@@ -1607,6 +1607,7 @@ class TestRecipientUserIdLinking:
                     "email": "alice@example.com",
                     "name": "Alice",
                     "user_id": "creator-456",
+                    "recipient_user_id": "user-123",
                 }
             ]
         }
@@ -1641,18 +1642,18 @@ class TestRecipientUserIdLinking:
         mock_resource_ctx.__aexit__ = AsyncMock(return_value=None)
 
         with patch.object(service.session, "resource", return_value=mock_resource_ctx):
-            echoes = await service.get_received_echoes(
-                user_id="user-123",
-                recipient_email="alice@example.com",
-            )
+            echoes = await service.get_received_echoes(user_id="user-123")
 
         assert len(echoes) == 1
         assert echoes[0].echo_id == "echo-abc"
 
-        # Exactly one query on recipients table, using email-index
+        # Recipients query uses recipient-user-id-index keyed on user_id
         assert mock_recipients_table.query.call_count == 1
         call_kwargs = mock_recipients_table.query.call_args_list[0][1]
-        assert call_kwargs.get("IndexName") == "email-index"
+        assert call_kwargs.get("IndexName") == "recipient-user-id-index"
+        assert (
+            call_kwargs.get("ExpressionAttributeValues", {}).get(":uid") == "user-123"
+        )
 
         # Echoes query uses KeyConditionExpression (not FilterExpression) for status
         echoes_call_kwargs = mock_echoes_table.query.call_args_list[0][1]
@@ -1662,16 +1663,14 @@ class TestRecipientUserIdLinking:
         )
 
     @pytest.mark.asyncio
-    async def test_get_received_echoes_returns_empty_when_not_a_recipient(self):
-        """get_received_echoes returns [] when no recipient record matches the email."""
+    async def test_get_received_echoes_returns_empty_when_not_linked(self):
+        """get_received_echoes returns [] when no recipient row links to user_id."""
         from src.app.services.echo_service import EchoService
 
         service = EchoService()
 
         mock_recipients_table = AsyncMock()
-        mock_recipients_table.query.return_value = {
-            "Items": []
-        }  # No matching recipient
+        mock_recipients_table.query.return_value = {"Items": []}
 
         mock_dynamodb = AsyncMock()
         mock_dynamodb.Table = AsyncMock(return_value=mock_recipients_table)
@@ -1681,11 +1680,124 @@ class TestRecipientUserIdLinking:
         mock_resource_ctx.__aexit__ = AsyncMock(return_value=None)
 
         with patch.object(service.session, "resource", return_value=mock_resource_ctx):
-            echoes = await service.get_received_echoes(
-                user_id="user-999",
-                recipient_email="nobody@example.com",
-            )
+            echoes = await service.get_received_echoes(user_id="user-999")
 
         assert echoes == []
-        # Only the recipients lookup ran — no echo queries
         assert mock_recipients_table.query.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_get_received_echoes_skips_soft_deleted_recipient_rows(self):
+        """Soft-deleted recipient rows must not contribute to the inbox."""
+        from src.app.services.echo_service import EchoService
+
+        service = EchoService()
+
+        mock_recipients_table = AsyncMock()
+        mock_recipients_table.query.return_value = {
+            "Items": [
+                {
+                    "recipient_id": "rec-soft-deleted",
+                    "email": "alice@example.com",
+                    "name": "Alice",
+                    "user_id": "creator-456",
+                    "recipient_user_id": "user-123",
+                    "deleted_at": "2026-01-01T00:00:00Z",
+                }
+            ]
+        }
+
+        mock_dynamodb = AsyncMock()
+        mock_dynamodb.Table = AsyncMock(return_value=mock_recipients_table)
+
+        mock_resource_ctx = MagicMock()
+        mock_resource_ctx.__aenter__ = AsyncMock(return_value=mock_dynamodb)
+        mock_resource_ctx.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(service.session, "resource", return_value=mock_resource_ctx):
+            echoes = await service.get_received_echoes(user_id="user-123")
+
+        assert echoes == []
+
+    @pytest.mark.asyncio
+    async def test_get_received_echoes_requires_user_id(self):
+        """Empty user_id must raise ValidationError, not silently return []."""
+        from src.app.core.exceptions import ValidationError
+        from src.app.services.echo_service import EchoService
+
+        service = EchoService()
+
+        with pytest.raises(ValidationError):
+            await service.get_received_echoes(user_id="")
+
+    @pytest.mark.asyncio
+    async def test_link_user_to_recipients_patches_unlinked_rows(self):
+        """link_user_to_recipients sets recipient_user_id on unlinked rows."""
+        from src.app.services.echo_service import EchoService
+
+        service = EchoService()
+
+        mock_table = AsyncMock()
+        mock_table.query.return_value = {
+            "Items": [
+                {
+                    "recipient_id": "rec-unlinked",
+                    "email": "new@example.com",
+                    "user_id": "creator-1",
+                },  # no recipient_user_id
+                {
+                    "recipient_id": "rec-already-linked",
+                    "email": "new@example.com",
+                    "user_id": "creator-2",
+                    "recipient_user_id": "user-123",
+                },
+                {
+                    "recipient_id": "rec-deleted",
+                    "email": "new@example.com",
+                    "user_id": "creator-3",
+                    "deleted_at": "2026-01-01T00:00:00Z",
+                },
+                {
+                    "recipient_id": "rec-foreign-link",
+                    "email": "new@example.com",
+                    "user_id": "creator-4",
+                    "recipient_user_id": "someone-else",
+                },
+            ]
+        }
+
+        mock_dynamodb = AsyncMock()
+        mock_dynamodb.Table = AsyncMock(return_value=mock_table)
+
+        mock_resource_ctx = MagicMock()
+        mock_resource_ctx.__aenter__ = AsyncMock(return_value=mock_dynamodb)
+        mock_resource_ctx.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(service.session, "resource", return_value=mock_resource_ctx):
+            linked = await service.link_user_to_recipients(
+                user_id="user-123", email="NEW@example.com"
+            )
+
+        # Only rec-unlinked should have been patched
+        assert linked == 1
+        assert mock_table.update_item.call_count == 1
+        update_kwargs = mock_table.update_item.call_args_list[0][1]
+        assert update_kwargs["Key"] == {"recipient_id": "rec-unlinked"}
+        assert update_kwargs["ExpressionAttributeValues"][":uid"] == "user-123"
+        # Email lookup is lower-cased
+        assert (
+            mock_table.query.call_args_list[0][1]["ExpressionAttributeValues"][":email"]
+            == "new@example.com"
+        )
+
+    @pytest.mark.asyncio
+    async def test_link_user_to_recipients_handles_empty_inputs(self):
+        """Empty user_id or email returns 0 without touching DynamoDB."""
+        from src.app.services.echo_service import EchoService
+
+        service = EchoService()
+
+        with patch.object(service.session, "resource") as mock_resource:
+            assert await service.link_user_to_recipients("", "x@y.com") == 0
+            assert await service.link_user_to_recipients("u-1", "") == 0
+            assert await service.link_user_to_recipients("u-1", "   ") == 0
+            mock_resource.assert_not_called()


### PR DESCRIPTION
The inbox endpoint was matching recipient rows via the email-index GSI using the caller's email from the JWT. Cognito access tokens don't carry an email claim, and security.map_claims_to_profile silently substituted sub/username, so the email lookup ran against a UUID and returned no rows. Production users saw empty inboxes despite having released echoes.

Switch get_received_echoes to query recipient-user-id-index by Cognito sub. The GSI is already provisioned in serverless.yml and Active in production. Drop the recipient_email parameter and the email path in the route — sub is in every JWT and is authoritative.

Back-link recipient rows on signup confirmation. Without this, recipients added by email before the recipient signed up stay unlinked forever. auth_controller.confirm_email now calls echo_service.link_user_to_recipients after the user profile is created; failures are logged but don't block confirmation (the offline backfill script is the recovery path).

Add scripts/backfill_recipient_user_id.py to patch legacy rows where recipient_user_id is empty but the email matches a registered user. Idempotent; --dry-run flag. Production dry-run shows zero rows need backfilling — the dataset is already consistent — but the script stays in-tree as a recovery tool.

Stop substituting sub/username for missing email in map_claims_to_profile. Returning a UUID-shaped string as "email" was the root cause; now absent claims surface as None so callers fail loudly instead of silently breaking downstream lookups.

Tests: replace 2 inbox tests with 6 new tests covering the new index path, soft-delete skip, empty user_id validation, and link_user_to_recipients (linked / already-linked / foreign-link / soft-deleted / empty-input). 58 echo_vault + 22 auth/security + 2 recipient_access tests pass.