### PR TITLE
fix: status filter on recipient-echoes-index + sanitize 5xx responses

### DIFF
--- a/src/app/api/echo_routes.py
+++ b/src/app/api/echo_routes.py
@@ -243,11 +243,20 @@ async def list_received_echoes(
     if not user_id:
         raise HTTPException(status_code=400, detail="User ID not found in token")
 
-    echoes = await echo_service.get_received_echoes(
-        user_id=user_id,
-        category=category,
-        sender_id=sender_id,
-    )
+    try:
+        echoes = await echo_service.get_received_echoes(
+            user_id=user_id,
+            category=category,
+            sender_id=sender_id,
+        )
+    except Exception:
+        # Full traceback already logged inside the service. Surface a friendly
+        # message to the client — never leak DynamoDB / boto error text.
+        logger.exception(f"Inbox load failed for user {user_id}")
+        raise HTTPException(
+            status_code=503,
+            detail="We couldn't load your inbox right now. Please try again.",
+        )
 
     return {
         "success": True,

--- a/src/app/core/error_handlers.py
+++ b/src/app/core/error_handlers.py
@@ -89,9 +89,16 @@ async def base_api_exception_handler(request: Request, exc: Exception) -> Respon
         },
     )
 
+    # 5xx messages must never be sent to clients verbatim — they often contain
+    # stack frames, AWS SDK error strings, or internal identifiers. Replace
+    # with a generic message; the real text is in the logs above.
+    user_facing_message = exc.message
+    if exc.status_code >= 500 and not is_development:
+        user_facing_message = "Something went wrong. Please try again."
+
     response_data: Dict[str, Any] = {
         "success": False,
-        "error": exc.message,
+        "error": user_facing_message,
         "requestId": request_id,
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }

--- a/src/app/services/echo_service.py
+++ b/src/app/services/echo_service.py
@@ -422,15 +422,18 @@ class EchoService:
                 )
 
                 # Query released echoes for each matched recipient.
-                # recipient-echoes-index: hash=recipient_id, sort=status — use both
-                # in the KeyConditionExpression to avoid a full scan + filter.
+                # recipient-echoes-index has hash=recipient_id only (no sort key),
+                # so status must be applied as a FilterExpression rather than a
+                # second KeyConditionExpression — DynamoDB rejects a 2-condition
+                # KCE against a 1-attribute key schema with ValidationException.
                 echoes_table = await dynamodb.Table(self.echoes_table)
                 echoes = []
 
                 for rid in recipient_ids:
                     response = await echoes_table.query(
                         IndexName="recipient-echoes-index",
-                        KeyConditionExpression="recipient_id = :rid AND #status = :released",
+                        KeyConditionExpression="recipient_id = :rid",
+                        FilterExpression="#status = :released",
                         ExpressionAttributeNames={"#status": "status"},
                         ExpressionAttributeValues={
                             ":rid": rid,

--- a/tests/test_echo_vault.py
+++ b/tests/test_echo_vault.py
@@ -1655,11 +1655,15 @@ class TestRecipientUserIdLinking:
             call_kwargs.get("ExpressionAttributeValues", {}).get(":uid") == "user-123"
         )
 
-        # Echoes query uses KeyConditionExpression (not FilterExpression) for status
+        # recipient-echoes-index has hash=recipient_id only, so status must be
+        # applied via FilterExpression — not a second key condition. Anything
+        # else triggers ValidationException at runtime.
         echoes_call_kwargs = mock_echoes_table.query.call_args_list[0][1]
+        assert echoes_call_kwargs.get("KeyConditionExpression") == "recipient_id = :rid"
+        assert echoes_call_kwargs.get("FilterExpression") == "#status = :released"
         assert (
-            "RELEASED"
-            in echoes_call_kwargs.get("ExpressionAttributeValues", {}).values()
+            echoes_call_kwargs.get("ExpressionAttributeValues", {}).get(":released")
+            == "RELEASED"
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
The recipient-echoes-index GSI is hash-only (recipient_id) — no sort key. The previous query used a 2-condition KeyConditionExpression ("recipient_id = :rid AND #status = :released"), which DynamoDB rejects with ValidationException ("number of query conditions (2) exceeds the number of key attributes defined in the schema (1)").

This was a latent bug masked by the previous email-based recipient lookup always returning [], so the echoes loop never executed. Now that the inbox correctly resolves recipients via recipient-user-id-index, the loop runs and the bad query surfaced.

Move the status condition to a FilterExpression. Cheaper than rebuilding the GSI to add a sort key, and per-recipient partitions are small enough that filter overhead is negligible.

Also: the inbox endpoint was returning the raw boto exception text to the client ("An error occurred (ValidationException) when calling the Query operation..."). Two layers of fix:
  - Inbox route: catch service exceptions and surface a friendly 503 "We couldn't load your inbox right now" message.
  - Global handler: in base_api_exception_handler, replace exc.message with "Something went wrong. Please try again." for any 5xx in production. Real message stays in CloudWatch logs.

Updated test to assert KeyConditionExpression / FilterExpression shape. 82 tests pass (echo_vault + auth + security + recipient_access).