### PR TITLE
feat(echoes): include release_date and lock_date in vault list response

### DIFF
--- a/src/app/api/echo_routes.py
+++ b/src/app/api/echo_routes.py
@@ -219,6 +219,8 @@ async def list_user_echoes(
                 "status": e.status.value,
                 "recipient_id": e.recipient_id,
                 "recipient": e.recipient,
+                "release_date": e.release_date,
+                "lock_date": e.lock_date,
                 "created_at": e.created_at,
             }
             for e in echoes


### PR DESCRIPTION
The vault list projection in GET /api/echoes was missing release_date and lock_date. Without these the frontend cannot distinguish a scheduled DRAFT (waiting for the future-release date) from a guardian- LOCKED echo when rendering vault rows — every row falls back to the 'Saved' subtitle and no row can show 'Unlocks <date>' or 'Locked <date>'. Surface both fields so the client can derive UI state from (status, release_date, lock_date) authoritatively.

No behaviour change for existing callers — purely additive fields on the response payload. Tests still pass (58/58 in test_echo_vault.py).