### PR TITLE
feat(echoes): hourly scheduler that auto-releases due DRAFT echoes

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -199,6 +199,17 @@ functions:
           rate: cron(0 12 * * ? *)  # Run daily at 12:00 UTC
           description: Check trial expirations and send notifications
 
+  # Scheduled job: auto-release DRAFT echoes whose release_date has passed
+  echoReleaseScheduler:
+    handler: src/app/jobs/echo_release_job.lambda_handler
+    description: Hourly scan for DRAFT echoes due for auto-release
+    timeout: 300
+    memorySize: 256
+    events:
+      - schedule:
+          rate: cron(0 * * * ? *)  # Run hourly at minute 0 UTC
+          description: Auto-release scheduled echoes
+
 resources:
   Resources:
     UsersTable:

--- a/src/app/jobs/echo_release_job.py
+++ b/src/app/jobs/echo_release_job.py
@@ -1,0 +1,89 @@
+"""
+Scheduled job: auto-release DRAFT echoes whose release_date has passed.
+
+Triggered hourly by AWS EventBridge. Delegates the actual scan + release
+work to `EchoService.release_due_echoes`; this module's only job is the
+Lambda boilerplate (async runner, structured response, telemetry log).
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from ..services.echo_service import EchoService
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+async def release_due_echoes() -> Dict[str, Any]:
+    """
+    Scan for DRAFT echoes whose release_date has passed and release each.
+
+    Returns:
+        Dict with job execution results — `success`, `timestamp`, and the
+        breakdown from EchoService.release_due_echoes (scanned/released/
+        skipped/failed/errors).
+    """
+    try:
+        echo_service = EchoService()
+        logger.info("Starting echo auto-release scan")
+
+        result = await echo_service.release_due_echoes()
+
+        logger.info(
+            f"Echo auto-release scan complete: "
+            f"scanned={result.get('scanned', 0)}, "
+            f"released={result.get('released', 0)}, "
+            f"skipped={result.get('skipped', 0)}, "
+            f"failed={result.get('failed', 0)}"
+        )
+
+        return {
+            "success": True,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "results": result,
+        }
+
+    except Exception as e:
+        logger.error(f"Error in echo auto-release job: {e}", exc_info=True)
+        return {
+            "success": False,
+            "error": str(e),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+
+def lambda_handler(event: Dict, context: Any) -> Dict:
+    """
+    AWS Lambda handler for hourly scheduled echo releases.
+
+    Triggered by EventBridge (CloudWatch Events) on a cron schedule defined
+    in serverless.yml (`cron(0 * * * ? *)` — every hour at minute 0 UTC).
+
+    Args:
+        event: EventBridge event payload
+        context: Lambda context
+
+    Returns:
+        Dict with HTTP-style statusCode and the job result body.
+    """
+    import asyncio
+
+    logger.info(f"Echo auto-release job triggered by: {event.get('source', 'manual')}")
+
+    result = asyncio.run(release_due_echoes())
+
+    return {
+        "statusCode": 200 if result["success"] else 500,
+        "body": result,
+    }
+
+
+# For local testing
+if __name__ == "__main__":
+    import asyncio
+
+    print("Running echo auto-release scan locally...")
+    result = asyncio.run(release_due_echoes())
+    print(f"Result: {result}")

--- a/src/app/services/echo_service.py
+++ b/src/app/services/echo_service.py
@@ -656,6 +656,114 @@ class EchoService:
 
         return echo
 
+    async def release_due_echoes(self) -> Dict[str, Any]:
+        """
+        Find every DRAFT echo whose `release_date` has passed and release it.
+
+        Used by the hourly scheduler Lambda (`echo_release_job.lambda_handler`)
+        to close the gap left by `create_echo` — that path only auto-releases
+        when the echo is created with a past/now release_date; future dates
+        are left in DRAFT until something else picks them up. That "something
+        else" is this method.
+
+        Implementation notes:
+
+        - Uses a DynamoDB Scan with a FilterExpression on status + release_date.
+          Acceptable at current data volumes; if the table grows large, add a
+          GSI on `status` and switch this to a query.
+        - Per-echo release calls are guarded so one failure does not abort
+          the whole batch. Failures are counted and logged but not raised.
+        - Skips items where `release_date` is missing (no schedule = nothing
+          for the scheduler to act on; manual release path is unaffected).
+        - The release_echo call enforces the standard preconditions
+          (recipient required, no guardian, still DRAFT) — anything not
+          eligible falls into the failed count and is logged.
+
+        Returns:
+            Dict with keys: `scanned` (raw item count), `released`,
+            `skipped` (no recipient / no schedule / guardian-locked),
+            `failed`, `errors` (truncated list of error strings).
+        """
+        from boto3.dynamodb.conditions import Attr
+
+        now_iso = _current_timestamp()
+        scanned = released = skipped = failed = 0
+        errors: List[str] = []
+
+        try:
+            async with self.session.resource(
+                "dynamodb", **self._get_dynamodb_kwargs()
+            ) as dynamodb:
+                table = await dynamodb.Table(self.echoes_table)
+
+                # Page through scan results — DynamoDB caps single-page size
+                # to 1MB, so we loop on ExclusiveStartKey for large tables.
+                scan_kwargs: Dict[str, Any] = {
+                    "FilterExpression": (
+                        Attr("status").eq(EchoStatus.DRAFT.value)
+                        & Attr("release_date").lte(now_iso)
+                        & Attr("deleted_at").not_exists()
+                    ),
+                }
+
+                while True:
+                    response = await table.scan(**scan_kwargs)
+                    for item in response.get("Items", []):
+                        scanned += 1
+                        echo_id = item.get("echo_id")
+                        owner_user_id = item.get("user_id")
+
+                        if not echo_id or not owner_user_id:
+                            failed += 1
+                            errors.append(
+                                f"Malformed echo row missing echo_id/user_id: "
+                                f"{item.get('echo_id', '<no id>')}"
+                            )
+                            continue
+
+                        # Items with a guardian go through the guardian flow;
+                        # release_echo rejects them with ValidationError, but
+                        # filtering early keeps the log clean.
+                        if item.get("guardian_id"):
+                            skipped += 1
+                            continue
+                        if not item.get("recipient_id"):
+                            skipped += 1
+                            continue
+
+                        try:
+                            await self.release_echo(echo_id, owner_user_id)
+                            released += 1
+                            logger.info(
+                                f"Auto-released echo {echo_id} (owner={owner_user_id}, "
+                                f"release_date={item.get('release_date')})"
+                            )
+                        except Exception as e:
+                            failed += 1
+                            msg = f"Failed to release echo {echo_id}: {e}"
+                            logger.warning(msg)
+                            # Bound the errors list so a bad batch doesn't
+                            # produce an unreadable response payload.
+                            if len(errors) < 20:
+                                errors.append(msg)
+
+                    last_key = response.get("LastEvaluatedKey")
+                    if not last_key:
+                        break
+                    scan_kwargs["ExclusiveStartKey"] = last_key
+
+        except ClientError as e:
+            logger.error(f"DynamoDB error scanning for due echoes: {e}", exc_info=True)
+            raise InternalServerError(f"Scheduler scan failed: {str(e)}")
+
+        return {
+            "scanned": scanned,
+            "released": released,
+            "skipped": skipped,
+            "failed": failed,
+            "errors": errors,
+        }
+
     async def lock_echo(self, echo_id: str, user_id: str) -> Echo:
         """
         Lock an echo with a guardian, preventing further edits and notifying the guardian.

--- a/tests/test_echo_vault.py
+++ b/tests/test_echo_vault.py
@@ -1013,6 +1013,224 @@ def echo_client():
         yield c
 
 
+# ============================================================
+# SECTION 3.5 — Unit tests: EchoService.release_due_echoes (scheduler)
+# ============================================================
+
+
+class TestEchoServiceReleaseDueEchoes:
+    """
+    Coverage for the scheduler entry point that the hourly Lambda calls.
+
+    The method scans the echoes table for DRAFTs with a past release_date
+    and releases each. These tests exercise the orchestration — the per-
+    echo release is delegated to release_echo (already covered above), so
+    we just verify it's invoked with the right (echo_id, owner_user_id)
+    pair and that failures are isolated to individual rows.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _stub_aws_creds(self, monkeypatch):
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+    def _wire_scan_mock(self, service, scan_pages):
+        """
+        Patch the DynamoDB resource so successive table.scan() calls return
+        `scan_pages` in order (a list of {"Items": [...], "LastEvaluatedKey": ?}
+        dicts). The final page must omit LastEvaluatedKey to terminate the loop.
+        """
+        mock_table = AsyncMock()
+        mock_table.scan = AsyncMock(side_effect=scan_pages)
+
+        mock_dynamodb = AsyncMock()
+        mock_dynamodb.Table = AsyncMock(return_value=mock_table)
+
+        mock_resource_ctx = MagicMock()
+        mock_resource_ctx.__aenter__ = AsyncMock(return_value=mock_dynamodb)
+        mock_resource_ctx.__aexit__ = AsyncMock(return_value=None)
+
+        return mock_table, patch.object(
+            service.session, "resource", return_value=mock_resource_ctx
+        )
+
+    @pytest.mark.asyncio
+    async def test_release_due_echoes_releases_each_match(self):
+        """Every scanned row gets a release_echo call with its own owner id."""
+        from src.app.services.echo_service import EchoService
+
+        service = EchoService()
+        scan_pages = [
+            {
+                "Items": [
+                    {
+                        "echo_id": "e-1",
+                        "user_id": "u-1",
+                        "recipient_id": "r-1",
+                        "release_date": "2026-01-01T00:00:00Z",
+                    },
+                    {
+                        "echo_id": "e-2",
+                        "user_id": "u-2",
+                        "recipient_id": "r-2",
+                        "release_date": "2026-02-01T00:00:00Z",
+                    },
+                ],
+            }
+        ]
+        _, scan_ctx = self._wire_scan_mock(service, scan_pages)
+        release_mock = AsyncMock()
+
+        with scan_ctx, patch.object(service, "release_echo", new=release_mock):
+            result = await service.release_due_echoes()
+
+        assert release_mock.call_count == 2
+        # Each release call must use the owning user_id from the scanned row,
+        # not a system identity — release_echo's get_echo() depends on it.
+        release_mock.assert_any_await("e-1", "u-1")
+        release_mock.assert_any_await("e-2", "u-2")
+        assert result["released"] == 2
+        assert result["failed"] == 0
+        assert result["skipped"] == 0
+
+    @pytest.mark.asyncio
+    async def test_release_due_echoes_skips_guardian_locked_rows(self):
+        """Rows with a guardian_id go through the guardian flow, not this one."""
+        from src.app.services.echo_service import EchoService
+
+        service = EchoService()
+        scan_pages = [
+            {
+                "Items": [
+                    {
+                        "echo_id": "e-guard",
+                        "user_id": "u-1",
+                        "recipient_id": "r-1",
+                        "guardian_id": "g-1",
+                        "release_date": "2026-01-01T00:00:00Z",
+                    },
+                ],
+            }
+        ]
+        _, scan_ctx = self._wire_scan_mock(service, scan_pages)
+        release_mock = AsyncMock()
+
+        with scan_ctx, patch.object(service, "release_echo", new=release_mock):
+            result = await service.release_due_echoes()
+
+        release_mock.assert_not_awaited()
+        assert result["skipped"] == 1
+        assert result["released"] == 0
+
+    @pytest.mark.asyncio
+    async def test_release_due_echoes_skips_rows_without_recipient(self):
+        """Echoes without a recipient_id cannot be released — skip cleanly."""
+        from src.app.services.echo_service import EchoService
+
+        service = EchoService()
+        scan_pages = [
+            {
+                "Items": [
+                    {
+                        "echo_id": "e-orphan",
+                        "user_id": "u-1",
+                        "release_date": "2026-01-01T00:00:00Z",
+                    },
+                ],
+            }
+        ]
+        _, scan_ctx = self._wire_scan_mock(service, scan_pages)
+        release_mock = AsyncMock()
+
+        with scan_ctx, patch.object(service, "release_echo", new=release_mock):
+            result = await service.release_due_echoes()
+
+        release_mock.assert_not_awaited()
+        assert result["skipped"] == 1
+        assert result["released"] == 0
+
+    @pytest.mark.asyncio
+    async def test_release_due_echoes_continues_past_per_echo_failure(self):
+        """One bad echo must not stop the batch; failure is counted + logged."""
+        from src.app.services.echo_service import EchoService
+
+        service = EchoService()
+        scan_pages = [
+            {
+                "Items": [
+                    {
+                        "echo_id": "e-good",
+                        "user_id": "u-1",
+                        "recipient_id": "r-1",
+                        "release_date": "2026-01-01T00:00:00Z",
+                    },
+                    {
+                        "echo_id": "e-bad",
+                        "user_id": "u-2",
+                        "recipient_id": "r-2",
+                        "release_date": "2026-01-01T00:00:00Z",
+                    },
+                ],
+            }
+        ]
+        _, scan_ctx = self._wire_scan_mock(service, scan_pages)
+
+        async def fake_release(echo_id, user_id):
+            if echo_id == "e-bad":
+                raise RuntimeError("simulated failure")
+
+        release_mock = AsyncMock(side_effect=fake_release)
+
+        with scan_ctx, patch.object(service, "release_echo", new=release_mock):
+            result = await service.release_due_echoes()
+
+        assert release_mock.call_count == 2
+        assert result["released"] == 1
+        assert result["failed"] == 1
+        assert len(result["errors"]) == 1
+        assert "e-bad" in result["errors"][0]
+
+    @pytest.mark.asyncio
+    async def test_release_due_echoes_paginates_through_scan_results(self):
+        """Multi-page scans (DynamoDB LastEvaluatedKey) loop until exhausted."""
+        from src.app.services.echo_service import EchoService
+
+        service = EchoService()
+        scan_pages = [
+            {
+                "Items": [
+                    {
+                        "echo_id": "e-1",
+                        "user_id": "u-1",
+                        "recipient_id": "r-1",
+                        "release_date": "2026-01-01T00:00:00Z",
+                    }
+                ],
+                "LastEvaluatedKey": {"echo_id": "e-1"},
+            },
+            {
+                "Items": [
+                    {
+                        "echo_id": "e-2",
+                        "user_id": "u-2",
+                        "recipient_id": "r-2",
+                        "release_date": "2026-01-01T00:00:00Z",
+                    }
+                ],
+            },
+        ]
+        mock_table, scan_ctx = self._wire_scan_mock(service, scan_pages)
+        release_mock = AsyncMock()
+
+        with scan_ctx, patch.object(service, "release_echo", new=release_mock):
+            result = await service.release_due_echoes()
+
+        assert mock_table.scan.call_count == 2
+        assert release_mock.call_count == 2
+        assert result["released"] == 2
+
+
 class TestReleaseEchoEndpoint:
     """
     Integration tests for the PATCH /api/echoes/{echo_id}/release route.


### PR DESCRIPTION
Closes the gap left by create_echo's auto-release: that path only fires when the echo is created with a past/now release_date. Echoes scheduled for the future stay in DRAFT until something reads them — until now, that "something" did not exist.

New pieces:

  src/app/jobs/echo_release_job.py
    Lambda handler modelled on trial_expiration_job.py. Async runner
    invokes EchoService.release_due_echoes and emits a structured
    summary log + response payload.

  src/app/services/echo_service.py
    release_due_echoes() — paginates a DynamoDB scan filtered on
    status=DRAFT AND release_date <= now AND deleted_at not_exists.
    For each match it dispatches to release_echo using the echo's own
    user_id (no auth bypass — the existing per-call check still runs).
    Rows with a guardian_id or no recipient_id are counted as skipped
    rather than released (guardian flow handles its own; orphans
    can't be released until a recipient is attached).

  serverless.yml
    New `echoReleaseScheduler` function with `cron(0 * * * ? *)` —
    runs at minute 0 of every hour UTC. Same memory/timeout as
    trialExpirationCheck (256MB / 300s).

  tests/test_echo_vault.py
    TestEchoServiceReleaseDueEchoes — 5 cases covering happy path
    (multi-echo batch), guardian skip, no-recipient skip, single-row
    failure isolation, and DynamoDB pagination via LastEvaluatedKey.

Scan vs GSI: a full scan is acceptable at current data volumes (~1MB per page, hourly cadence). If the echoes table grows large enough that hourly scans become expensive, add a GSI on `status` and switch this to a Query — the rest of the orchestration stays the same.