### PR TITLE
chore: align serverless.yml memorySize with deployed value (512 -> 1024)

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -6,7 +6,7 @@ provider:
   runtime: python3.11
   region: us-east-1
   stage: ${opt:stage, env:STAGE, 'staging'}
-  memorySize: 512
+  memorySize: 1024
   timeout: 30
   environment:
     ALLOWED_ORIGINS: ${env:ALLOWED_ORIGINS, 'http://localhost:3000'}


### PR DESCRIPTION
The deployed api Lambda was manually bumped to 1024 MB but serverless.yml still declared 512 MB. Any future `serverless deploy` would have reverted the deployed function. Cron functions (trialExpirationCheck, echoReleaseScheduler) stay at 256 MB.