### PR TITLE
security: scrub PII logs and tighten dev-mode bypass

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -181,12 +181,72 @@ provider:
             - arn:aws:cognito-idp:${self:provider.region}:*:userpool/*
   logs:
     http: true
+  httpApi:
+    # JWT authorizer wired at gateway boundary. The backend (core/security.py)
+    # ALSO verifies the JWT signature via JWKS as defense-in-depth — both layers
+    # must pass for a request to reach a protected route. Cognito access tokens
+    # carry client_id (not aud); AWS HTTP API authorizer accepts either claim
+    # when validating against the `audience` setting.
+    authorizers:
+      cognitoJwtAuthorizer:
+        type: jwt
+        identitySource: $request.header.Authorization
+        issuerUrl: https://cognito-idp.${self:provider.region}.amazonaws.com/${env:COGNITO_USER_POOL_ID}
+        audience:
+          - ${env:COGNITO_CLIENT_ID}
 
 functions:
   api:
     handler: src/app/handler.handler
     events:
-      - httpApi: '*'
+      # ---- Public routes (no authorizer) ----
+      # Health checks (monitors / load balancers).
+      - httpApi:
+          method: GET
+          path: /health
+      - httpApi:
+          method: GET
+          path: /health/detailed
+      - httpApi:
+          method: GET
+          path: /api/health
+      - httpApi:
+          method: GET
+          path: /api/mirrorgpt/health
+      # Auth endpoints — must be reachable before the user has a token.
+      - httpApi:
+          method: POST
+          path: /api/auth/register
+      - httpApi:
+          method: POST
+          path: /api/auth/login
+      - httpApi:
+          method: POST
+          path: /api/auth/forgot-password
+      - httpApi:
+          method: POST
+          path: /api/auth/reset-password
+      - httpApi:
+          method: POST
+          path: /api/auth/refresh
+      - httpApi:
+          method: POST
+          path: /api/auth/confirm-email
+      - httpApi:
+          method: POST
+          path: /api/auth/resend-verification-code
+      # IAP webhooks — Apple/Google sign the payload; signature is verified
+      # by receipt_validator. Cognito JWT does not apply.
+      - httpApi:
+          method: POST
+          path: /verify-purchase
+      # ---- Authenticated catch-all ----
+      # Every other route requires a valid Cognito JWT.
+      - httpApi:
+          method: '*'
+          path: '*'
+          authorizer:
+            name: cognitoJwtAuthorizer
 
   # Scheduled job for trial expiration checks
   trialExpirationCheck:

--- a/src/app/core/security.py
+++ b/src/app/core/security.py
@@ -1,8 +1,10 @@
 import logging
 import os
 from datetime import datetime, timezone
+from threading import Lock
 from typing import Any, Dict, List, Optional
 
+import requests
 from fastapi import Depends, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
@@ -17,6 +19,105 @@ ALGORITHM = "RS256"
 security = HTTPBearer(auto_error=False)
 
 
+# --------------------------------------------------------------------------- #
+# JWKS fetch + cache (defense-in-depth on top of API Gateway JWT authorizer)
+# --------------------------------------------------------------------------- #
+# Cognito rotates signing keys rarely. We fetch the JWKS once per warm Lambda
+# container and refresh on `kid` cache miss. The lock prevents concurrent
+# refresh from racing on cold-start fan-in.
+_JWKS_CACHE: Optional[Dict[str, Any]] = None
+_JWKS_LOCK = Lock()
+
+
+def _jwks_url() -> str:
+    region = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or "us-east-1"
+    pool_id = os.getenv("COGNITO_USER_POOL_ID", "")
+    return f"https://cognito-idp.{region}.amazonaws.com/{pool_id}/.well-known/jwks.json"
+
+
+def _expected_issuer() -> str:
+    region = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or "us-east-1"
+    pool_id = os.getenv("COGNITO_USER_POOL_ID", "")
+    return f"https://cognito-idp.{region}.amazonaws.com/{pool_id}"
+
+
+def _fetch_jwks(force: bool = False) -> Dict[str, Any]:
+    global _JWKS_CACHE
+    cached = _JWKS_CACHE
+    if cached is not None and not force:
+        return cached
+    with _JWKS_LOCK:
+        cached = _JWKS_CACHE
+        if cached is not None and not force:
+            return cached
+        resp = requests.get(_jwks_url(), timeout=5)
+        resp.raise_for_status()
+        fresh: Dict[str, Any] = resp.json()
+        _JWKS_CACHE = fresh
+        return fresh
+
+
+def _find_key(jwks: Dict[str, Any], kid: str) -> Optional[Dict[str, Any]]:
+    for k in jwks.get("keys", []):
+        if k.get("kid") == kid:
+            return k
+    return None
+
+
+def _verify_jwt_signature(token: str) -> Dict[str, Any]:
+    """Verify a Cognito JWT signature against the User Pool JWKS.
+
+    Cognito access tokens carry `client_id` (no `aud`); ID tokens carry `aud`.
+    We disable jose's `aud` check and validate the client claim explicitly so
+    both token types are accepted.
+    """
+    expected_client_id = os.getenv("COGNITO_CLIENT_ID", "")
+    if not expected_client_id:
+        raise InvalidTokenError("COGNITO_CLIENT_ID is not configured")
+
+    try:
+        headers = jwt.get_unverified_header(token)
+    except JWTError as e:
+        raise InvalidTokenError(f"Malformed token header: {e}") from e
+
+    kid = headers.get("kid")
+    if not kid:
+        raise InvalidTokenError("Token missing 'kid' header")
+
+    jwks = _fetch_jwks()
+    key = _find_key(jwks, kid)
+    if key is None:
+        # Signing key rotated since the last cache refresh — pull JWKS once
+        # more before giving up.
+        jwks = _fetch_jwks(force=True)
+        key = _find_key(jwks, kid)
+    if key is None:
+        raise InvalidTokenError("Token signed by an unknown key")
+
+    try:
+        payload = jwt.decode(
+            token,
+            key,
+            algorithms=[ALGORITHM],
+            issuer=_expected_issuer(),
+            options={"verify_aud": False},
+        )
+    except JWTError as e:
+        raise InvalidTokenError(f"JWT signature verification failed: {e}") from e
+
+    token_use = payload.get("token_use")
+    if token_use == "access":
+        if payload.get("client_id") != expected_client_id:
+            raise InvalidTokenError("Access token client_id mismatch")
+    elif token_use == "id":
+        if payload.get("aud") != expected_client_id:
+            raise InvalidTokenError("ID token aud mismatch")
+    else:
+        raise InvalidTokenError(f"Unexpected token_use: {token_use!r}")
+
+    return payload
+
+
 def decode_cognito_jwt(token: str) -> Optional[Dict[str, Any]]:
     """
     Decode and validate Cognito JWT token
@@ -24,19 +125,19 @@ def decode_cognito_jwt(token: str) -> Optional[Dict[str, Any]]:
     This is primarily for local development and fallback scenarios
     """
     try:
-        # For development/testing: decode without signature verification
-        # In production, API Gateway handles JWT verification
+        # In dev/test, tests supply synthetic tokens that aren't signed by
+        # Cognito; we skip signature verification there. In every other env
+        # the JWT is signature-verified via JWKS so a forged token cannot
+        # reach a protected route even if the API Gateway authorizer is ever
+        # misconfigured or removed.
         is_development = os.getenv("NODE_ENV") in ["development", "test"]
 
         if is_development:
             logger.debug("🔧 Development: Decoding JWT without signature verification")
-            # Decode without verification for development
             payload = jwt.get_unverified_claims(token)
         else:
-            # In production, we should trust API Gateway's validation
-            # But decode payload for user info extraction
-            payload = jwt.get_unverified_claims(token)
-            logger.debug("✅ Production: Extracting claims from pre-validated JWT")
+            payload = _verify_jwt_signature(token)
+            logger.debug("✅ Production: JWT signature verified")
 
         # Debug: Log the payload to understand what's missing
         logger.info(f"🔍 JWT Token Claims: {payload}")

--- a/src/app/core/security.py
+++ b/src/app/core/security.py
@@ -19,6 +19,18 @@ ALGORITHM = "RS256"
 security = HTTPBearer(auto_error=False)
 
 
+def _is_dev_environment() -> bool:
+    """Single source of truth for the dev/test bypass.
+
+    Gated strictly on ENVIRONMENT to avoid auth-bypass risk: previously this
+    also honored NODE_ENV/DEBUG, so a stray `DEBUG=true` env var in a
+    deployed stack would grant `mock-user-123` to any tokenless request.
+    The rest of the codebase already uses ENVIRONMENT (see logging_config.py,
+    echo_v1_routes.py); this aligns security.py with that convention.
+    """
+    return os.getenv("ENVIRONMENT", "").lower() in {"development", "test"}
+
+
 # --------------------------------------------------------------------------- #
 # JWKS fetch + cache (defense-in-depth on top of API Gateway JWT authorizer)
 # --------------------------------------------------------------------------- #
@@ -130,19 +142,12 @@ def decode_cognito_jwt(token: str) -> Optional[Dict[str, Any]]:
         # the JWT is signature-verified via JWKS so a forged token cannot
         # reach a protected route even if the API Gateway authorizer is ever
         # misconfigured or removed.
-        is_development = os.getenv("NODE_ENV") in ["development", "test"]
-
-        if is_development:
+        if _is_dev_environment():
             logger.debug("🔧 Development: Decoding JWT without signature verification")
             payload = jwt.get_unverified_claims(token)
         else:
             payload = _verify_jwt_signature(token)
             logger.debug("✅ Production: JWT signature verified")
-
-        # Debug: Log the payload to understand what's missing
-        logger.info(f"🔍 JWT Token Claims: {payload}")
-        email_claim = payload.get("email")
-        logger.info(f"🔍 Email claim value: {email_claim}")
 
         # Basic validation
         now = datetime.now(timezone.utc)
@@ -177,8 +182,6 @@ def decode_cognito_jwt(token: str) -> Optional[Dict[str, Any]]:
 
 def map_claims_to_profile(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Map Cognito JWT claims to user profile format"""
-    logger.info(f"🔍 Mapping claims to profile. Input payload: {payload}")
-
     groups: List[str] = payload.get("cognito:groups", []) or []
 
     # Email comes only from the 'email' claim. Cognito ACCESS tokens do not
@@ -196,8 +199,6 @@ def map_claims_to_profile(payload: Dict[str, Any]) -> Dict[str, Any]:
             "Endpoints that need the user's email must resolve it via the "
             "users table by sub. Available claims: " + ", ".join(payload.keys())
         )
-
-    logger.info(f"🔍 Extracted email from payload: {email}")
 
     profile = {
         "id": payload.get("sub"),
@@ -217,7 +218,6 @@ def map_claims_to_profile(payload: Dict[str, Any]) -> Dict[str, Any]:
         "features": [],
     }
 
-    logger.info(f"🔍 Final mapped profile: {profile}")
     return profile
 
 
@@ -229,9 +229,7 @@ async def get_current_user(
     Dependency to get current authenticated user from JWT token
     Extracts and validates user information from Cognito JWT tokens
     """
-    is_dev_env = os.getenv("NODE_ENV") in ["development", "test"]
-    is_debug = os.getenv("DEBUG", "false").lower() == "true"
-    is_development = is_dev_env or is_debug
+    is_development = _is_dev_environment()
 
     # Try to get token from Authorization header
     token = None


### PR DESCRIPTION
Two related security cleanups in core/security.py:

1. **Remove 5 per-request PII INFO logs** that fired on every authenticated API call: - decode_cognito_jwt: full JWT payload + email claim - map_claims_to_profile: input payload, extracted email, final profile

   These were debugging aids that shipped to production. CloudWatch ingest cost aside, dumping the entire JWT payload plus email at INFO is a PII leak with regulatory exposure (GDPR, CCPA). The "no email in access token" warning at map_claims_to_profile remains — it carries no PII.

2. **Tighten the dev-mode mock-user bypass.** Previously the bypass was gated on `NODE_ENV in {development, test}` OR `DEBUG=true`. A stray `DEBUG=true` env var in any deployed stack would grant the request mock-user-123's identity when no token is present. Replaces both call sites with a single _is_dev_environment() helper that gates strictly on `ENVIRONMENT in {development, test}` — aligning with the rest of the codebase (logging_config.py, echo_v1_routes.py).

Tests still pass: conftest.py already sets ENVIRONMENT=test alongside NODE_ENV=test and DEBUG=true.