### PR TITLE
perf: skip Cognito get_user when ID-token claims are present

### DIFF
--- a/src/app/core/enhanced_auth.py
+++ b/src/app/core/enhanced_auth.py
@@ -1,9 +1,40 @@
 """
-Enhanced user dependencies for profile data
+Enhanced user dependencies for profile data.
+
+Wave 1B perf change — skip Cognito GetUser on the hot path
+==========================================================
+The original implementation called ``cognito_service.get_user(access_token)``
+on every request behind ``get_user_with_profile``. AWS Cognito's GetUser is
+account-wide capped at ~120 RPS, which becomes the single largest quota
+cliff in the system once the app sees 1k+ concurrent users.
+
+The fix has two layers:
+
+1. **Claim short-circuit.** ``get_current_user`` (in ``core/security.py``)
+   already maps the JWT claims into a profile dict. When the caller sends
+   an **ID token**, the claims include ``email``, ``given_name``,
+   ``family_name`` and ``email_verified`` — everything we need for the
+   "enhanced" profile. In that case we synthesize ``enhanced_user``
+   directly from ``current_user`` and skip Cognito entirely.
+
+2. **In-process TTL cache.** When the caller sends an access token only
+   (no ``email``/``firstName``/``lastName`` claims), we still need
+   GetUser. We cache the result keyed by Cognito ``sub`` for
+   ``COGNITO_PROFILE_CACHE_TTL_SECONDS`` (default 300s) so subsequent
+   requests from the same warm Lambda container reuse the resolved
+   profile. The cache is module-level state guarded by a ``Lock`` and
+   capped via an ``OrderedDict`` (LRU eviction).
+
+If both paths fail we still return ``_create_fallback_user`` so
+endpoints depending on this never 500 because of a profile lookup.
 """
 
 import logging
-from typing import Any, Dict
+import os
+import time
+from collections import OrderedDict
+from threading import Lock
+from typing import Any, Dict, Optional, Tuple
 
 from fastapi import Depends, Request
 
@@ -12,89 +43,258 @@ from .security import get_current_user
 
 logger = logging.getLogger(__name__)
 
+# --------------------------------------------------------------------------- #
+# In-process profile cache
+# --------------------------------------------------------------------------- #
+# Maps Cognito sub -> (expires_at_epoch_seconds, profile_dict).
+# Module-level state is intentional: a warm Lambda container reuses this
+# between invocations, which is exactly what we want for cutting GetUser RPS.
+# The cache is keyed strictly by sub so it cannot leak across user
+# identities.
+_PROFILE_CACHE: "OrderedDict[str, Tuple[float, Dict[str, Any]]]" = OrderedDict()
+_PROFILE_CACHE_LOCK = Lock()
+_PROFILE_CACHE_MAX_ENTRIES = 10_000
 
+
+def _cache_ttl_seconds() -> int:
+    """TTL for the in-process profile cache, configurable via env var."""
+    raw = os.getenv("COGNITO_PROFILE_CACHE_TTL_SECONDS", "300")
+    try:
+        ttl = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid COGNITO_PROFILE_CACHE_TTL_SECONDS=%r, using default 300",
+            raw,
+        )
+        return 300
+    return ttl if ttl > 0 else 300
+
+
+def _evict_expired(now: float) -> None:
+    """Drop any entries whose TTL has elapsed. Caller must hold the lock."""
+    expired_keys = [
+        key for key, (expires_at, _) in _PROFILE_CACHE.items() if expires_at <= now
+    ]
+    for key in expired_keys:
+        _PROFILE_CACHE.pop(key, None)
+
+
+def _cache_get(sub: str) -> Optional[Dict[str, Any]]:
+    """Return a cached profile for sub if still fresh, else None."""
+    if not sub:
+        return None
+    now = time.monotonic()
+    with _PROFILE_CACHE_LOCK:
+        entry = _PROFILE_CACHE.get(sub)
+        if entry is None:
+            return None
+        expires_at, profile = entry
+        if expires_at <= now:
+            _PROFILE_CACHE.pop(sub, None)
+            return None
+        # LRU bump
+        _PROFILE_CACHE.move_to_end(sub)
+        return profile
+
+
+def _cache_set(sub: str, profile: Dict[str, Any]) -> None:
+    """Store a profile for sub with the configured TTL."""
+    if not sub:
+        return
+    ttl = _cache_ttl_seconds()
+    now = time.monotonic()
+    expires_at = now + ttl
+    with _PROFILE_CACHE_LOCK:
+        _evict_expired(now)
+        _PROFILE_CACHE[sub] = (expires_at, profile)
+        _PROFILE_CACHE.move_to_end(sub)
+        # Cap size with LRU eviction
+        while len(_PROFILE_CACHE) > _PROFILE_CACHE_MAX_ENTRIES:
+            _PROFILE_CACHE.popitem(last=False)
+
+
+def _reset_cache_for_tests() -> None:
+    """Test-only helper: clear the in-process cache between scenarios."""
+    with _PROFILE_CACHE_LOCK:
+        _PROFILE_CACHE.clear()
+
+
+# --------------------------------------------------------------------------- #
+# Profile assembly helpers
+# --------------------------------------------------------------------------- #
+def _build_display_name(
+    given_name: str,
+    family_name: str,
+    email: str,
+    user_id: str,
+    extra: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Mirror the legacy display-name logic.
+
+    Order of preference:
+      1. "given_name family_name"
+      2. attrs["name"]
+      3. attrs["preferred_username"]
+      4. email prefix (before "@")
+      5. "User-<first 8 chars of sub>"
+    """
+    display_name = f"{given_name} {family_name}".strip()
+    if not display_name and extra:
+        display_name = extra.get("name") or ""
+    if not display_name and extra:
+        display_name = extra.get("preferred_username") or ""
+    if not display_name and email:
+        display_name = email.split("@")[0]
+    if not display_name:
+        display_name = f"User-{(user_id or '')[:8]}"
+    return display_name
+
+
+def _profile_from_jwt_claims(current_user: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Return enhanced_user synthesized from JWT claims, or None if missing.
+
+    Returns None when the JWT did not carry enough profile info — typically
+    because the caller sent an access token (which Cognito does not put
+    name/email claims on). In that case the caller must fall back to
+    Cognito GetUser (with caching) before giving up.
+    """
+    email = current_user.get("email") or ""
+    first_name = current_user.get("firstName") or ""
+    last_name = current_user.get("lastName") or ""
+
+    # We need at least email AND (first_name OR last_name) to consider the
+    # JWT "enriched enough" to skip Cognito. Email alone is not enough
+    # because some legacy paths populate it from elsewhere; we want the
+    # name fields too to truly avoid the GetUser dependency.
+    if not email or not (first_name or last_name):
+        return None
+
+    user_id = current_user.get("id") or current_user.get("sub") or ""
+    display_name = _build_display_name(first_name, last_name, email, user_id)
+
+    return {
+        **current_user,
+        "email": email,
+        "firstName": first_name,
+        "lastName": last_name,
+        "name": display_name,
+        "emailVerified": bool(current_user.get("emailVerified", False)),
+        "cognitoUsername": current_user.get("cognitoUsername", ""),
+        "userStatus": current_user.get("userStatus", "UNKNOWN"),
+    }
+
+
+def _profile_from_cognito(
+    current_user: Dict[str, Any], cognito_user: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Build enhanced_user dict from a Cognito GetUser response."""
+    attrs: Dict[str, Any] = cognito_user.get("userAttributes") or {}
+    given_name = attrs.get("given_name", "") or ""
+    family_name = attrs.get("family_name", "") or ""
+    email = attrs.get("email") or current_user.get("email") or ""
+    user_id = current_user.get("id") or current_user.get("sub") or ""
+
+    display_name = _build_display_name(
+        given_name, family_name, email, user_id, extra=attrs
+    )
+
+    return {
+        **current_user,
+        "email": email,
+        "firstName": given_name,
+        "lastName": family_name,
+        "name": display_name,
+        "emailVerified": str(attrs.get("email_verified", "false")).lower() == "true",
+        "cognitoUsername": cognito_user.get("username", ""),
+        "userStatus": cognito_user.get("userStatus", "UNKNOWN"),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# FastAPI dependency
+# --------------------------------------------------------------------------- #
 async def get_user_with_profile(
     request: Request,
     current_user: Dict[str, Any] = Depends(get_current_user),
     cognito_service: CognitoService = Depends(get_cognito_service),
 ) -> Dict[str, Any]:
-    """
-    Enhanced user dependency that fetches full profile data from Cognito
+    """Return a user profile enriched with name/email/verified flags.
 
-    This handles the case where access tokens don't contain profile info
-    by using Cognito's get_user API with the same access token
+    Resolution order:
+      1. If the JWT already carried email + given_name/family_name claims
+         (ID token path), build the enhanced user directly from those
+         claims — **no Cognito call**.
+      2. Else, consult the in-process TTL cache keyed by sub. If we have
+         a fresh entry, use it — **no Cognito call**.
+      3. Else, call ``cognito_service.get_user(access_token)`` and cache
+         the resulting profile.
+      4. If all of the above fail, return ``_create_fallback_user``.
     """
-
-    try:
-        # Extract the access token from the request
-        access_token = None
-        auth_header = request.headers.get("authorization") or request.headers.get(
-            "Authorization"
+    # Step 1: try to satisfy from JWT claims alone.
+    jwt_profile = _profile_from_jwt_claims(current_user)
+    if jwt_profile is not None:
+        logger.debug(
+            "enhanced_auth: served profile from JWT claims (no Cognito call) "
+            "for sub=%s",
+            current_user.get("id"),
         )
-        if auth_header and auth_header.lower().startswith("bearer "):
-            access_token = auth_header.split(" ", 1)[1]
+        return jwt_profile
 
+    sub = current_user.get("id") or current_user.get("sub") or ""
+
+    # Step 2: try the cache.
+    cached = _cache_get(sub) if sub else None
+    if cached is not None:
+        logger.debug(
+            "enhanced_auth: served profile from cache (no Cognito call) for sub=%s",
+            sub,
+        )
+        return cached
+
+    # Step 3: fall back to Cognito GetUser with the bearer access token.
+    try:
+        access_token = _extract_bearer_token(request)
         if not access_token:
             logger.warning("No access token found in request for profile fetch")
             return _create_fallback_user(current_user)
 
-        # Fetch full user profile from Cognito
         cognito_user = await cognito_service.get_user(access_token)
-
         if cognito_user and cognito_user.get("userAttributes"):
-            attrs = cognito_user["userAttributes"]
-
-            # Extract profile information from Cognito attributes
-            given_name = attrs.get("given_name", "")
-            family_name = attrs.get("family_name", "")
-            email = attrs.get("email", current_user.get("email", ""))
-
-            # Create display name
-            display_name = f"{given_name} {family_name}".strip()
-            if not display_name:
-                display_name = attrs.get("name", "")
-            if not display_name:
-                display_name = attrs.get("preferred_username", "")
-            if not display_name:
-                if email:
-                    display_name = email.split("@")[0]
-                else:
-                    display_name = f"User-{current_user['id'][:8]}"
-
-            # Create enhanced user profile
-            enhanced_user = {
-                **current_user,
-                "email": email,
-                "firstName": given_name,
-                "lastName": family_name,
-                "name": display_name,
-                "emailVerified": attrs.get("email_verified", "false").lower() == "true",
-                "cognitoUsername": cognito_user.get("username", ""),
-                "userStatus": cognito_user.get("userStatus", "UNKNOWN"),
-            }
-
+            enhanced_user = _profile_from_cognito(current_user, cognito_user)
+            if sub:
+                _cache_set(sub, enhanced_user)
             logger.info(
-                f"Enhanced user profile created for {email or current_user['id']}"
+                "Enhanced user profile created for %s",
+                enhanced_user.get("email") or current_user.get("id"),
             )
             return enhanced_user
 
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 — log + fall through to fallback
         logger.warning(
-            f"Failed to fetch Cognito profile for user {current_user['id']}: {str(e)}"
+            "Failed to fetch Cognito profile for user %s: %s",
+            current_user.get("id"),
+            str(e),
         )
 
-    # Fallback to basic user data
+    # Step 4: final fallback (never raises).
     return _create_fallback_user(current_user)
 
 
-def _create_fallback_user(current_user: Dict[str, Any]) -> Dict[str, Any]:
-    """Create fallback user profile when Cognito data is unavailable"""
-
-    fallback_name = (
-        current_user.get("email", "").split("@")[0]
-        if current_user.get("email")
-        else f"User-{current_user['id'][:8]}"
+def _extract_bearer_token(request: Request) -> Optional[str]:
+    """Pull the bearer token out of the Authorization header, if any."""
+    auth_header = request.headers.get("authorization") or request.headers.get(
+        "Authorization"
     )
+    if auth_header and auth_header.lower().startswith("bearer "):
+        return auth_header.split(" ", 1)[1]
+    return None
+
+
+def _create_fallback_user(current_user: Dict[str, Any]) -> Dict[str, Any]:
+    """Create fallback user profile when Cognito data is unavailable."""
+    email = current_user.get("email", "") or ""
+    user_id = current_user.get("id") or current_user.get("sub") or ""
+    fallback_name = email.split("@")[0] if email else f"User-{user_id[:8]}"
 
     return {
         **current_user,

--- a/tests/test_enhanced_auth.py
+++ b/tests/test_enhanced_auth.py
@@ -1,0 +1,314 @@
+"""
+Tests for :mod:`src.app.core.enhanced_auth`.
+
+These tests verify the Wave 1B perf change that drops Cognito GetUser from
+the per-request auth path:
+
+  1. When the JWT already carries email/firstName/lastName, no Cognito
+     call is issued.
+  2. When the JWT lacks those fields, the first call hits Cognito and
+     subsequent calls within the TTL window are served from cache.
+  3. After the TTL elapses, the next call re-hits Cognito.
+  4. If both the JWT short-circuit and Cognito GetUser fail, the
+     fallback profile is returned (the endpoint never 500s on profile
+     resolution).
+
+We exercise ``get_user_with_profile`` directly as a coroutine with a
+stubbed FastAPI ``Request`` and a mock ``CognitoService`` — this keeps
+the tests focused on the new logic without spinning up the full app.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.app.core import enhanced_auth
+from src.app.core.enhanced_auth import (
+    _create_fallback_user,
+    _reset_cache_for_tests,
+    get_user_with_profile,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _make_request(authorization: str | None = "Bearer test-token") -> MagicMock:
+    """Build a minimal stand-in for ``fastapi.Request`` with headers."""
+    request = MagicMock()
+    headers: Dict[str, str] = {}
+    if authorization is not None:
+        headers["authorization"] = authorization
+    request.headers = headers
+    return request
+
+
+def _make_cognito_service(
+    get_user_return: Dict[str, Any] | None = None,
+    get_user_side_effect: Exception | None = None,
+) -> MagicMock:
+    """Build a mock CognitoService whose ``get_user`` is awaitable."""
+    svc = MagicMock()
+    if get_user_side_effect is not None:
+        svc.get_user = AsyncMock(side_effect=get_user_side_effect)
+    else:
+        svc.get_user = AsyncMock(return_value=get_user_return)
+    return svc
+
+
+def _jwt_user_with_claims() -> Dict[str, Any]:
+    """A current_user shaped like get_current_user output for an ID token."""
+    return {
+        "id": "sub-with-claims",
+        "email": "person@example.com",
+        "firstName": "Person",
+        "lastName": "Example",
+        "emailVerified": True,
+        "provider": "cognito",
+        "roles": ["basic_user"],
+    }
+
+
+def _jwt_user_access_token_only() -> Dict[str, Any]:
+    """A current_user shaped like get_current_user output for an access token.
+
+    Access tokens do not carry email/given_name/family_name in Cognito,
+    so map_claims_to_profile produces empty strings for those fields.
+    """
+    return {
+        "id": "sub-access-only",
+        "email": None,
+        "firstName": "",
+        "lastName": "",
+        "emailVerified": False,
+        "provider": "cognito",
+        "roles": ["basic_user"],
+    }
+
+
+def _cognito_get_user_payload() -> Dict[str, Any]:
+    """A realistic Cognito GetUser response, post-conversion."""
+    return {
+        "username": "person-cognito-username",
+        "userAttributes": {
+            "email": "person@example.com",
+            "given_name": "Person",
+            "family_name": "Example",
+            "email_verified": "true",
+        },
+        "enabled": True,
+        "userStatus": "CONFIRMED",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clear_profile_cache():
+    """Each test gets a clean module-level cache."""
+    _reset_cache_for_tests()
+    yield
+    _reset_cache_for_tests()
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 1: JWT claims short-circuit — no Cognito call
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_jwt_claims_short_circuit_skips_cognito():
+    """If current_user has email + first/last name, we never call Cognito."""
+    cognito = _make_cognito_service(get_user_return=_cognito_get_user_payload())
+    request = _make_request()
+
+    result = await get_user_with_profile(
+        request=request,
+        current_user=_jwt_user_with_claims(),
+        cognito_service=cognito,
+    )
+
+    cognito.get_user.assert_not_awaited()
+    assert result["email"] == "person@example.com"
+    assert result["firstName"] == "Person"
+    assert result["lastName"] == "Example"
+    assert result["name"] == "Person Example"
+    assert result["emailVerified"] is True
+    # Pre-existing fields from current_user should still be present.
+    assert result["roles"] == ["basic_user"]
+    assert result["provider"] == "cognito"
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 2: cache hit on the second call within TTL
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_second_call_within_ttl_is_served_from_cache(monkeypatch):
+    """First call hits Cognito; second call within TTL must not."""
+    # Keep the default TTL but make sure we don't rely on env state.
+    monkeypatch.delenv("COGNITO_PROFILE_CACHE_TTL_SECONDS", raising=False)
+
+    cognito = _make_cognito_service(get_user_return=_cognito_get_user_payload())
+    request = _make_request()
+
+    user = _jwt_user_access_token_only()
+
+    first = await get_user_with_profile(
+        request=request,
+        current_user=user,
+        cognito_service=cognito,
+    )
+    second = await get_user_with_profile(
+        request=request,
+        current_user=user,
+        cognito_service=cognito,
+    )
+
+    assert cognito.get_user.await_count == 1, "Cognito should be hit exactly once"
+    assert first == second
+    assert first["email"] == "person@example.com"
+    assert first["firstName"] == "Person"
+    assert first["lastName"] == "Example"
+    assert first["name"] == "Person Example"
+    assert first["emailVerified"] is True
+    assert first["cognitoUsername"] == "person-cognito-username"
+    assert first["userStatus"] == "CONFIRMED"
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 3: cache expiry — Cognito is re-hit after the TTL elapses
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_cache_expiry_triggers_cognito_refetch(monkeypatch):
+    """Once the TTL elapses, the next call must hit Cognito again."""
+    # Fake monotonic clock under our control.
+    clock = {"now": 1_000.0}
+
+    def fake_monotonic() -> float:
+        return clock["now"]
+
+    monkeypatch.setattr(enhanced_auth.time, "monotonic", fake_monotonic)
+    monkeypatch.setenv("COGNITO_PROFILE_CACHE_TTL_SECONDS", "60")
+
+    cognito = _make_cognito_service(get_user_return=_cognito_get_user_payload())
+    request = _make_request()
+    user = _jwt_user_access_token_only()
+
+    await get_user_with_profile(
+        request=request,
+        current_user=user,
+        cognito_service=cognito,
+    )
+    assert cognito.get_user.await_count == 1
+
+    # Advance just past the TTL.
+    clock["now"] += 61.0
+
+    await get_user_with_profile(
+        request=request,
+        current_user=user,
+        cognito_service=cognito,
+    )
+    assert (
+        cognito.get_user.await_count == 2
+    ), "Cognito should be re-hit after TTL elapses"
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 4: fallback when both JWT claims and Cognito are unavailable
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_fallback_when_jwt_missing_and_cognito_raises():
+    """If JWT claims are empty AND Cognito raises, we get the fallback."""
+    cognito = _make_cognito_service(
+        get_user_side_effect=RuntimeError("Cognito unreachable")
+    )
+    request = _make_request()
+    user = _jwt_user_access_token_only()
+
+    result = await get_user_with_profile(
+        request=request,
+        current_user=user,
+        cognito_service=cognito,
+    )
+
+    assert cognito.get_user.await_count == 1
+    expected_fallback = _create_fallback_user(user)
+    assert result == expected_fallback
+    assert result["firstName"] == ""
+    assert result["lastName"] == ""
+    assert result["emailVerified"] is False
+    assert result["userStatus"] == "UNKNOWN"
+
+
+# --------------------------------------------------------------------------- #
+# Extra coverage: cache isolation between distinct subs
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_cache_does_not_leak_between_users():
+    """Two different subs must each get their own Cognito lookup + entry."""
+
+    def _payload_for(email: str, given: str, family: str) -> Dict[str, Any]:
+        return {
+            "username": f"{given.lower()}-username",
+            "userAttributes": {
+                "email": email,
+                "given_name": given,
+                "family_name": family,
+                "email_verified": "true",
+            },
+            "enabled": True,
+            "userStatus": "CONFIRMED",
+        }
+
+    payloads: List[Dict[str, Any]] = [
+        _payload_for("alice@example.com", "Alice", "A"),
+        _payload_for("bob@example.com", "Bob", "B"),
+    ]
+    cognito = MagicMock()
+    cognito.get_user = AsyncMock(side_effect=payloads)
+    request = _make_request()
+
+    user_a = {**_jwt_user_access_token_only(), "id": "sub-alice"}
+    user_b = {**_jwt_user_access_token_only(), "id": "sub-bob"}
+
+    res_a = await get_user_with_profile(
+        request=request, current_user=user_a, cognito_service=cognito
+    )
+    res_b = await get_user_with_profile(
+        request=request, current_user=user_b, cognito_service=cognito
+    )
+
+    assert cognito.get_user.await_count == 2
+    assert res_a["email"] == "alice@example.com"
+    assert res_b["email"] == "bob@example.com"
+
+    # Second call for each user must reuse cache.
+    res_a2 = await get_user_with_profile(
+        request=request, current_user=user_a, cognito_service=cognito
+    )
+    res_b2 = await get_user_with_profile(
+        request=request, current_user=user_b, cognito_service=cognito
+    )
+    assert cognito.get_user.await_count == 2
+    assert res_a2["email"] == "alice@example.com"
+    assert res_b2["email"] == "bob@example.com"
+
+
+# --------------------------------------------------------------------------- #
+# Sanity: running the module under plain ``asyncio.run`` works too.
+# --------------------------------------------------------------------------- #
+def test_sync_smoke_call() -> None:
+    """Smoke test: invoking the coroutine via asyncio.run works end-to-end."""
+    cognito = _make_cognito_service(get_user_return=_cognito_get_user_payload())
+    request = _make_request()
+
+    result = asyncio.run(
+        get_user_with_profile(
+            request=request,
+            current_user=_jwt_user_with_claims(),
+            cognito_service=cognito,
+        )
+    )
+    assert result["name"] == "Person Example"
+    cognito.get_user.assert_not_awaited()


### PR DESCRIPTION
Cognito's GetUser API is account-wide capped at ~120 RPS. The old get_user_with_profile dependency called it on every authenticated request, making it the single largest quota cliff in the system once the app sees 1k+ concurrent users (80x over at 10k concurrent).

This change drops the per-request GetUser call in two layers:

1. JWT claim short-circuit. get_current_user already produces a profile from JWT claims via map_claims_to_profile(). When the caller sends an ID token, those claims include email, given_name, family_name, and email_verified — everything we need. In that case we synthesize the enhanced_user directly from current_user and skip Cognito.

2. In-process TTL cache. For callers that send an access token only (which Cognito does not put name/email claims on), we still need GetUser. Results are cached keyed by Cognito sub for COGNITO_PROFILE_CACHE_TTL_SECONDS (default 300s) so subsequent requests from the same warm Lambda container reuse the profile.

Cache implementation notes:
- Module-level OrderedDict with LRU eviction at 10k entries cap.
- threading.Lock guards all mutations.
- Strictly keyed by sub so it cannot leak across user identities.
- TTL stored as time.monotonic() epoch — immune to wall-clock skew.

If both the JWT short-circuit and Cognito fail, the existing _create_fallback_user path is preserved so endpoints still never 500 on profile resolution.

Tests in tests/test_enhanced_auth.py cover:
- JWT claim short-circuit skips Cognito entirely
- First call hits Cognito, second call within TTL is cached
- Cache expiry forces a re-fetch after TTL elapses
- Fallback returned when JWT claims missing AND Cognito raises
- Cache isolation between distinct user subs