### PR TITLE
perf: tighten OpenAI defaults — model, max_tokens, timeout

### DIFF
--- a/src/app/services/openai_service.py
+++ b/src/app/services/openai_service.py
@@ -96,12 +96,25 @@ class OpenAIService(IMirrorChatRepository):
         if not api_key:
             raise ValueError("OPENAI_API_KEY environment variable is required")
 
-        self.client = OpenAI(api_key=api_key)
-        # High-performance model selection - gpt-4o for better quality
-        # and faster response
-        self.model = os.getenv("OPENAI_MODEL", "gpt-4o")
+        # timeout=20.0 keeps us well inside Lambda's 30s budget; the SDK
+        # default of 600s would let a hung OpenAI request time the Lambda
+        # out without the client ever cancelling. max_retries=1 means
+        # one retry on transient errors (network/5xx), instead of the SDK
+        # default of 2 which compounds inside the same Lambda invocation.
+        self.client = OpenAI(api_key=api_key, timeout=20.0, max_retries=1)
+        # gpt-4o-mini is the conversational default — the system prompt
+        # asks for short, conversational replies that the mini model
+        # handles well at ~5-10% of the cost of gpt-4o. Callers that need
+        # higher reasoning (e.g. a "deep reflection" mode) should pass a
+        # specific model via send_with_overrides instead of changing this
+        # default.
+        self.model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
         self.temperature = float(os.getenv("OPENAI_TEMPERATURE", "0.7"))
-        self.max_tokens = int(os.getenv("OPENAI_MAX_TOKENS", "1000"))
+        # 450 tokens ≈ 340 words — plenty for the 1-3 sentence replies the
+        # system prompt requests. The previous 1000 default let responses
+        # drift much longer than the conversational tone calls for and was
+        # the dominant per-call cost driver.
+        self.max_tokens = int(os.getenv("OPENAI_MAX_TOKENS", "450"))
 
         logger.info(f"OpenAI service initialized with model: {self.model}")
 


### PR DESCRIPTION
Three surgical changes to OpenAIService.__init__ that compound into a large reduction in per-chat OpenAI spend and a tighter latency tail.

1. **Default model gpt-4o → gpt-4o-mini.** The MirrorGPT system prompt asks for short conversational replies. gpt-4o-mini handles that register well at ~5-10% of gpt-4o's per-token cost. Callers needing higher reasoning (deep reflections, etc.) should pass an explicit model via send_with_overrides — the override path already exists and is used by ConversationSummarizer.

2. **Default max_tokens 1000 → 450.** ~340 words is plenty for 1-3 sentence replies. The 1000-token default let responses drift well past the conversational tone and was the dominant per-call cost driver.

3. **timeout=20.0, max_retries=1 on the OpenAI client.** The SDK default timeout is 600s — far past Lambda's 30s budget — so a hung request would time the Lambda out without the SDK ever cancelling. 20s gives ~10s headroom before Lambda terminates. SDK default retries=2 would compound inside the same Lambda invocation against that budget; we drop to 1.

Both env vars (OPENAI_MODEL, OPENAI_MAX_TOKENS) remain tunable per stage via serverless.yml or the AWS console, so any opt-in to gpt-4o or a longer cap can be made without a code change.

Estimated impact:
  - 60-80% reduction in per-chat OpenAI cost
  - Slight latency improvement (mini responds faster than 4o)
  - Bounded Lambda exposure to OpenAI hangs (20s vs 600s)