### PR TITLE
fix(tests+mypy): green the test suite + clear mypy error on main

### DIFF
--- a/src/app/services/receipt_validator.py
+++ b/src/app/services/receipt_validator.py
@@ -392,7 +392,10 @@ def _payload_to_dict(payload: Any) -> Dict[str, Any]:
         return {}
     if isinstance(payload, dict):
         return payload
-    if is_dataclass(payload):
+    # ``is_dataclass`` returns True for both class objects and instances;
+    # ``asdict`` only accepts instances. Guard against the class-object case
+    # (mypy's type narrowing also requires this).
+    if is_dataclass(payload) and not isinstance(payload, type):
         data = asdict(payload)
     else:
         # Try generic attribute scrape as a last resort.

--- a/tests/test_email_async_boto3.py
+++ b/tests/test_email_async_boto3.py
@@ -13,12 +13,29 @@ import pytest
 
 
 def test_ses_client_config_has_max_pool_connections():
-    """The module-level _SES_CLIENT_CONFIG must be tuned."""
+    """The module-level _SES_CLIENT_CONFIG must be tuned.
+
+    Robust to botocore's Config normalization: depending on whether the
+    Config has been merged with another (which happens when other tests
+    in the suite construct boto3 clients), the ``retries`` dict may
+    surface ``max_attempts`` (the value we set), ``total_max_attempts``
+    (max_attempts + 1, what botocore actually uses internally), or both.
+    We accept either as long as the mode is adaptive and the attempts
+    value is what we configured.
+    """
     from src.app.services.email_service import _SES_CLIENT_CONFIG
 
     # botocore.Config sets attributes via __setattr__; they're not in type stubs.
     assert _SES_CLIENT_CONFIG.max_pool_connections == 50  # type: ignore[attr-defined]
-    assert _SES_CLIENT_CONFIG.retries == {"max_attempts": 5, "mode": "adaptive"}  # type: ignore[attr-defined]
+    retries = _SES_CLIENT_CONFIG.retries  # type: ignore[attr-defined]
+    assert retries.get("mode") == "adaptive"
+    # Either form is acceptable; pick whichever botocore exposed.
+    max_attempts = retries.get("max_attempts")
+    total_max_attempts = retries.get("total_max_attempts")
+    assert max_attempts == 5 or total_max_attempts == 6, (
+        f"Expected max_attempts=5 or total_max_attempts=6, got "
+        f"max_attempts={max_attempts!r}, total_max_attempts={total_max_attempts!r}"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_storage_quota_async_boto3.py
+++ b/tests/test_storage_quota_async_boto3.py
@@ -16,9 +16,16 @@ import pytest
 
 
 @pytest.fixture
-def quota_service_with_mock_s3():
-    """Build a StorageQuotaService with a MagicMock S3 client."""
-    os.environ.setdefault("ECHO_MEDIA_BUCKET", "test-bucket")
+def quota_service_with_mock_s3(monkeypatch):
+    """Build a StorageQuotaService with a MagicMock S3 client.
+
+    Uses ``monkeypatch.setenv`` instead of ``os.environ.setdefault`` because
+    setdefault is a no-op when ECHO_MEDIA_BUCKET is already set by the
+    project's ``.env`` or by another test fixture — and StorageQuotaService
+    reads the env var at __init__ time, baking the wrong value into
+    ``service.bucket``.
+    """
+    monkeypatch.setenv("ECHO_MEDIA_BUCKET", "test-bucket")
     mock_s3 = MagicMock()
     with patch("boto3.client", return_value=mock_s3):
         from src.app.services.storage_quota_service import StorageQuotaService


### PR DESCRIPTION
Three small fixes uncovered while reviewing main post-Wave-1-merge.

1. **mypy** — ``src/app/services/receipt_validator.py:396``: Argument 1 to "asdict" has incompatible type "DataclassInstance | type[DataclassInstance]"; expected "DataclassInstance"

   ``is_dataclass()`` returns True for both class objects and instances, but ``asdict()`` only accepts instances. Added an ``isinstance(payload, type)`` guard so mypy can narrow correctly. Behaviorally a no-op (we never pass a class object), but lets mypy pass cleanly.

2. **test_storage_quota_async_boto3.py::test_calculate_user_storage_ usage_iterates_in_threadpool** — was using ``os.environ.setdefault("ECHO_MEDIA_BUCKET", "test-bucket")`` which is a no-op when the env var is already set (by .env or by another test). ``StorageQuotaService.__init__`` reads the env var and bakes it into ``service.bucket`` at construction time, so the fixture gave the test the wrong bucket. Switched to ``monkeypatch.setenv(...)`` which always overrides and auto-restores per-test.

3. **test_email_async_boto3.py::test_ses_client_config_has_max_pool_ connections** — was asserting strict dict equality on ``_SES_CLIENT_CONFIG.retries``. Botocore's adaptive mode auto-derives ``total_max_attempts`` from ``max_attempts``, and depending on whether the Config has been merged elsewhere in the test suite the dict may expose only one of the two keys. Made the assertion robust to either form (5 max_attempts OR 6 total_max_attempts; mode must be ``adaptive``).

Validation:
  - Full suite: 602 passed, 2 skipped, 0 failed (was 600 passed, 2 failed before this commit).
  - mypy: 0 errors in receipt_validator.py (was 1 error before).