### PR TITLE
fix(infra): make /api/mirrorgpt/quiz/{questions,submit} public

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -247,6 +247,18 @@ functions:
       - httpApi:
           method: POST
           path: /verify-purchase
+      # Archetype Discovery Quiz — runs BEFORE signup as part of the
+      # onboarding flow, so the client has no Cognito JWT yet. The
+      # submission carries an optional ``anonymousId`` so the backend can
+      # link results to the user once they confirm their email. See
+      # ``src/services/api/quiz.ts`` on the mobile client — both endpoints
+      # are explicitly ``requiresAuth: false``.
+      - httpApi:
+          method: GET
+          path: /api/mirrorgpt/quiz/questions
+      - httpApi:
+          method: POST
+          path: /api/mirrorgpt/quiz/submit
       # ---- Authenticated catch-all ----
       # Every other route requires a valid Cognito JWT.
       - httpApi:


### PR DESCRIPTION
The Archetype Discovery Quiz runs as part of the pre-signup onboarding flow — the mobile client has no Cognito JWT at that point. The frontend's quiz API calls (src/services/api/quiz.ts on the mobile client) are explicitly ``requiresAuth: false``.

The JWT-authorizer PR (security/cognito-jwt-authorizer) didn't list these two routes as public, so the catch-all was rejecting them with
401. End-user impact: the alert "Unable to load quiz questions. Please check your connection and try again." on the quiz screen, blocking the entire signup funnel for new users.

Adds the two routes to the public list in serverless.yml, alongside the existing auth + health + IAP-webhook exceptions:

  - GET  /api/mirrorgpt/quiz/questions
  - POST /api/mirrorgpt/quiz/submit

Backend endpoints are read-only (questions) / append-only with an optional anonymousId (submit), so there's no per-user authorization to enforce here. The anonymousId gets linked to the real user once they confirm their email.

Validation:
  - YAML parses cleanly.
  - Diff is purely additive — no existing route's auth posture changes.