### PR TITLE
perf(pull): backend pull Tier 1 — parallel + dedupe presigns, strip l…

### DIFF
--- a/src/app/api/echo_routes.py
+++ b/src/app/api/echo_routes.py
@@ -350,7 +350,13 @@ async def list_received_echoes(
                     "name": e.user_id,  # TODO: enrich with Cognito display name
                     "email": "",
                 },
-                "media_url": e.media_url,
+                # NOTE: media_url is deliberately omitted from the inbox list
+                # response. The inbox card shows title/sender/category and
+                # navigates to a playback screen that fetches the detail
+                # endpoint (which signs media_url on demand). Eliminates the
+                # N wasted presigns per page and closes the regression that
+                # otherwise would have surfaced once the bucket public-access
+                # block was tightened in the upload-Tier-A PR.
                 "content": e.content,
                 "scheduled_at": e.release_date,
                 "created_at": e.created_at,

--- a/src/app/services/echo_service.py
+++ b/src/app/services/echo_service.py
@@ -528,8 +528,11 @@ class EchoService:
                 if status and echo.status.value != status:
                     continue
 
-                # Sign media URL for access
-                echo = await self._sign_media_url(echo)
+                # NOTE: media_url is deliberately NOT signed in the vault
+                # list path — the route response omits it. The detail
+                # endpoint (GET /echoes/{id}) signs media_url on demand
+                # when the player actually needs the URL. Eliminates N
+                # wasted presigns per page.
                 echoes.append(echo)
 
             next_cursor = encode_cursor(response.get("LastEvaluatedKey"))
@@ -554,9 +557,15 @@ class EchoService:
         (classic N+1). For a 50-echo page with 30 unique recipients that
         was 30 sequential round-trips on a cold cache.
 
-        New code: collect the distinct recipient_ids, fan them out across
-        ``BatchGetItem`` calls of up to 100 keys each in parallel, then
-        do dict lookups in the per-echo loop.
+        Current code:
+        1. Distinct recipient_ids fanned out via BatchGetItem (chunks of 100).
+        2. Distinct profile_image_url presigns done once each via
+           ``_sign_profile_urls`` (dedupe + parallel). The old serial
+           ``await self._sign_profile_url`` inside the per-echo loop was
+           the dominant tail-latency contributor on a warm cache: each
+           ``generate_presigned_url`` call adds ~10-30 ms of awaiting on
+           the aioboto3 client. 30 unique recipients = ~600 ms serial vs.
+           ~30 ms parallel.
         """
         recipient_ids = [
             echo.recipient_id for echo in echoes if echo.recipient_id is not None
@@ -570,25 +579,37 @@ class EchoService:
 
         recipients_by_id = await self._batch_get_recipients(distinct_ids, owner_user_id)
 
+        # Defense-in-depth ownership filter — same as before.
+        recipients_by_id = {
+            rid: r for rid, r in recipients_by_id.items() if r.user_id == owner_user_id
+        }
+
+        # Dedupe + parallel-sign distinct profile URLs.
+        distinct_profile_urls = {
+            r.profile_image_url
+            for r in recipients_by_id.values()
+            if r.profile_image_url
+        }
+        signed_by_url = await self._sign_profile_urls(distinct_profile_urls)
+
         for echo in echoes:
             if not echo.recipient_id:
                 continue
             recipient = recipients_by_id.get(echo.recipient_id)
             if recipient is None:
                 continue
-            # Defense in depth: ownership check. ``_batch_get_recipients``
-            # already filters on user_id, but a stray non-owner row should
-            # not leak through here.
-            if recipient.user_id != owner_user_id:
-                continue
+            canonical_profile = recipient.profile_image_url
+            signed_profile = (
+                signed_by_url.get(canonical_profile, canonical_profile)
+                if canonical_profile
+                else None
+            )
             echo.recipient = {
                 "recipient_id": recipient.recipient_id,
                 "name": recipient.name,
                 "email": recipient.email,
                 "motif": recipient.motif,
-                "profile_image_url": await self._sign_profile_url(
-                    recipient.profile_image_url
-                ),
+                "profile_image_url": signed_profile,
             }
 
     async def _batch_get_recipients(
@@ -1265,8 +1286,41 @@ class EchoService:
             logger.error(f"Failed to sign profile URL: {e}")
             return url  # Return original on error; image will 403 but app won't crash
 
+    async def _sign_profile_urls(
+        self, urls: "set[str] | frozenset[str]"
+    ) -> Dict[str, str]:
+        """Sign a batch of distinct profile URLs in parallel.
+
+        Returns a dict mapping each input URL to its signed counterpart.
+        Use over per-row ``await self._sign_profile_url(...)`` whenever
+        the caller iterates over a list — collapses N serial round-trips
+        into one ``asyncio.gather`` window. Failed signs fall through to
+        the original URL (same contract as the singular helper).
+
+        Args:
+            urls: Distinct canonical URLs to sign. Pass a set so the
+                caller can't accidentally pay for duplicates.
+
+        Returns:
+            ``{canonical_url: signed_url}``. Inputs already-signed or
+            non-S3 are returned unchanged (matches singular helper).
+        """
+        url_list = [u for u in urls if u]
+        if not url_list:
+            return {}
+        signed = await asyncio.gather(*[self._sign_profile_url(u) for u in url_list])
+        return {orig: new for orig, new in zip(url_list, signed) if new is not None}
+
     async def _sign_media_url(self, echo: Echo) -> Echo:
-        """Generate presigned GET URL for secure media playback."""
+        """Generate presigned GET URL for secure media playback.
+
+        TTL is 6 h. The previous 1 h was too short for users who park an
+        echo open on screen, lock their phone, and come back: the player
+        re-requested the URL and got a 403 once the original expired.
+        6 h is also well under the 12 h Lambda IAM-role session cap, so
+        Cognito Identity / STS credentials never invalidate before the
+        URL does.
+        """
         if echo.media_url and "amazonaws.com" in echo.media_url:
             try:
                 # Extract key from URL
@@ -1277,7 +1331,7 @@ class EchoService:
                 presigned_url = await s3.generate_presigned_url(
                     "get_object",
                     Params={"Bucket": self.s3_bucket, "Key": key},
-                    ExpiresIn=3600,  # 1 hour
+                    ExpiresIn=21600,  # 6 h
                 )
                 echo.media_url = presigned_url
             except Exception as e:
@@ -1489,14 +1543,23 @@ class EchoService:
 
             response = await table.query(**query_kwargs)
 
-            recipients: List[Recipient] = []
-            for item in response.get("Items", []):
-                recipient = Recipient.from_dynamodb_item(item)
-                if recipient.deleted_at is None:
-                    recipient.profile_image_url = await self._sign_profile_url(
-                        recipient.profile_image_url
+            # Filter soft-deletes, then dedupe + parallel-sign profile URLs.
+            # Old code awaited self._sign_profile_url(...) inside the per-row
+            # loop — serial across the page.
+            recipients: List[Recipient] = [
+                Recipient.from_dynamodb_item(item)
+                for item in response.get("Items", [])
+                if item.get("deleted_at") is None
+            ]
+            distinct_urls = {
+                r.profile_image_url for r in recipients if r.profile_image_url
+            }
+            signed_by_url = await self._sign_profile_urls(distinct_urls)
+            for r in recipients:
+                if r.profile_image_url:
+                    r.profile_image_url = signed_by_url.get(
+                        r.profile_image_url, r.profile_image_url
                     )
-                    recipients.append(recipient)
 
             next_cursor = encode_cursor(response.get("LastEvaluatedKey"))
             return recipients, next_cursor
@@ -1629,14 +1692,21 @@ class EchoService:
 
             response = await table.query(**query_kwargs)
 
-            guardians: List[Guardian] = []
-            for item in response.get("Items", []):
-                guardian = Guardian.from_dynamodb_item(item)
-                if guardian.deleted_at is None:
-                    guardian.profile_image_url = await self._sign_profile_url(
-                        guardian.profile_image_url
+            # Dedupe + parallel-sign profile URLs — same shape as recipients.
+            guardians: List[Guardian] = [
+                Guardian.from_dynamodb_item(item)
+                for item in response.get("Items", [])
+                if item.get("deleted_at") is None
+            ]
+            distinct_urls = {
+                g.profile_image_url for g in guardians if g.profile_image_url
+            }
+            signed_by_url = await self._sign_profile_urls(distinct_urls)
+            for g in guardians:
+                if g.profile_image_url:
+                    g.profile_image_url = signed_by_url.get(
+                        g.profile_image_url, g.profile_image_url
                     )
-                    guardians.append(guardian)
 
             next_cursor = encode_cursor(response.get("LastEvaluatedKey"))
             return guardians, next_cursor

--- a/tests/test_echo_pull_tier_1.py
+++ b/tests/test_echo_pull_tier_1.py
@@ -1,0 +1,250 @@
+"""Tests for PR2 — Backend pull Tier 1.
+
+Covers:
+- _sign_profile_urls: parallel + dedupe behavior
+- _sign_media_url: 6h TTL (was 1h)
+- get_user_echoes no longer signs media_url (route omits it; signing was
+  pure waste and prevented us from removing the unsigned-bucket fallback)
+- _enrich_echoes_with_recipients: dedupe + parallel profile-image presigns
+- Inbox route no longer leaks unsigned media_url (the locked-bucket fix
+  from PR1 would 403 these; the right fix is to omit them and force
+  detail-fetch)
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.app.models.echo import Echo, EchoStatus, EchoType, Recipient
+from src.app.services.echo_service import EchoService
+
+# ----------------------------------------------------------------------
+# _sign_profile_urls: parallel + dedupe
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sign_profile_urls_signs_each_distinct_url_once():
+    """Three distinct URLs → three sign calls; five duplicates → still three."""
+    svc = EchoService()
+    sign_calls: list[str] = []
+
+    async def fake_sign(url):
+        sign_calls.append(url)
+        return f"signed::{url}"
+
+    with patch.object(svc, "_sign_profile_url", side_effect=fake_sign):
+        result = await svc._sign_profile_urls(
+            {
+                "https://b.s3.amazonaws.com/p/u1.jpg",
+                "https://b.s3.amazonaws.com/p/u2.jpg",
+                "https://b.s3.amazonaws.com/p/u3.jpg",
+            }
+        )
+
+    assert len(sign_calls) == 3
+    assert len(result) == 3
+    for orig, signed in result.items():
+        assert signed == f"signed::{orig}"
+
+
+@pytest.mark.asyncio
+async def test_sign_profile_urls_handles_empty_set():
+    svc = EchoService()
+    assert await svc._sign_profile_urls(set()) == {}
+    assert await svc._sign_profile_urls(frozenset()) == {}
+
+
+@pytest.mark.asyncio
+async def test_sign_profile_urls_runs_in_parallel():
+    """Confirm gather is doing real fan-out, not sequential awaits.
+
+    Each fake sign sleeps 50ms. Five distinct URLs serial = 250 ms;
+    parallel = ~50 ms. Allow generous headroom for CI jitter.
+    """
+    import asyncio
+    import time
+
+    svc = EchoService()
+
+    async def slow_sign(url):
+        await asyncio.sleep(0.05)
+        return f"signed::{url}"
+
+    urls = {f"https://b.s3.amazonaws.com/p/u{i}.jpg" for i in range(5)}
+
+    with patch.object(svc, "_sign_profile_url", side_effect=slow_sign):
+        t0 = time.monotonic()
+        result = await svc._sign_profile_urls(urls)
+        elapsed = time.monotonic() - t0
+
+    assert len(result) == 5
+    # Serial would be ~0.25s; parallel must be well under that.
+    assert (
+        elapsed < 0.18
+    ), f"_sign_profile_urls did not fan out (elapsed={elapsed:.2f}s)"
+
+
+# ----------------------------------------------------------------------
+# _sign_media_url: TTL bump
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sign_media_url_uses_six_hour_ttl():
+    """1h was too short; users came back to 403s after locking their phone."""
+    svc = EchoService()
+    svc.s3_bucket = "b"
+    echo = Echo(
+        echo_id="e",
+        user_id="u",
+        title="t",
+        media_url="https://b.s3.us-east-1.amazonaws.com/echoes/u/e_2026.mp4",
+        echo_type=EchoType.VIDEO,
+        status=EchoStatus.RELEASED,
+    )
+    fake_s3 = AsyncMock()
+    fake_s3.generate_presigned_url = AsyncMock(return_value="signed")
+    with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+        await svc._sign_media_url(echo)
+
+    _args, kwargs = fake_s3.generate_presigned_url.call_args
+    assert kwargs["ExpiresIn"] == 21600  # 6 h
+
+
+# ----------------------------------------------------------------------
+# get_user_echoes no longer signs media_url (it isn't returned anyway)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_user_echoes_does_not_sign_media_url():
+    """Vault list response omits media_url; signing it was dead work."""
+    svc = EchoService()
+    items = [
+        {
+            "echo_id": f"echo-{i}",
+            "user_id": "u-1",
+            "title": f"Echo {i}",
+            "category": "general",
+            "echo_type": "VIDEO",
+            "status": "DRAFT",
+            "media_url": f"https://b.s3.us-east-1.amazonaws.com/echoes/u-1/e{i}.mp4",
+            "created_at": "2026-05-17T00:00:00Z",
+            "updated_at": "2026-05-17T00:00:00Z",
+        }
+        for i in range(3)
+    ]
+    table = AsyncMock()
+    table.query = AsyncMock(return_value={"Items": items, "LastEvaluatedKey": None})
+    resource = AsyncMock()
+    resource.Table = AsyncMock(return_value=table)
+
+    sign_calls: list[str] = []
+
+    async def spy_sign_media(echo):
+        sign_calls.append(echo.echo_id)
+        return echo
+
+    with patch.object(
+        svc, "_get_dynamodb_resource", new=AsyncMock(return_value=resource)
+    ):
+        with patch.object(svc, "_sign_media_url", side_effect=spy_sign_media):
+            with patch.object(
+                svc,
+                "_enrich_echoes_with_recipients",
+                new=AsyncMock(return_value=None),
+            ):
+                echoes, _cursor = await svc.get_user_echoes(user_id="u-1")
+
+    assert len(echoes) == 3
+    assert sign_calls == [], "media_url must not be signed in the vault list path"
+
+
+# ----------------------------------------------------------------------
+# _enrich_echoes_with_recipients: dedupe + parallel profile-image signing
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enrich_dedupes_profile_url_signs_across_repeated_recipients():
+    """Five echoes sharing two recipients → only 2 profile-URL signs."""
+    svc = EchoService()
+    r1 = Recipient(
+        recipient_id="r-1",
+        user_id="u-1",
+        name="Alice",
+        email="alice@e.com",
+        profile_image_url="https://b.s3.amazonaws.com/p/r1.jpg",
+    )
+    r2 = Recipient(
+        recipient_id="r-2",
+        user_id="u-1",
+        name="Bob",
+        email="bob@e.com",
+        profile_image_url="https://b.s3.amazonaws.com/p/r2.jpg",
+    )
+    echoes = [
+        Echo(echo_id=f"e-{i}", user_id="u-1", title="t", recipient_id="r-1")
+        for i in range(3)
+    ] + [
+        Echo(echo_id=f"e-{i}", user_id="u-1", title="t", recipient_id="r-2")
+        for i in range(2)
+    ]
+
+    sign_calls: list[str] = []
+
+    async def fake_sign(url):
+        sign_calls.append(url)
+        return f"signed::{url}"
+
+    with patch.object(
+        svc,
+        "_batch_get_recipients",
+        new=AsyncMock(return_value={"r-1": r1, "r-2": r2}),
+    ):
+        with patch.object(svc, "_sign_profile_url", side_effect=fake_sign):
+            await svc._enrich_echoes_with_recipients(echoes, owner_user_id="u-1")
+
+    # Five echoes → at most two distinct profile URLs → exactly 2 sign calls.
+    assert len(sign_calls) == 2, f"expected 2 distinct signs, got {len(sign_calls)}"
+
+    # And every echo's recipient should carry the signed URL.
+    for e in echoes:
+        assert e.recipient is not None
+        signed = e.recipient["profile_image_url"]
+        assert signed.startswith("signed::")
+
+
+@pytest.mark.asyncio
+async def test_enrich_drops_non_owner_recipients_before_signing():
+    """Defense-in-depth: a misconfigured GSI could return a recipient owned by
+    someone else. We must not sign or attach those — they'd leak the
+    foreign profile URL into the response.
+    """
+    svc = EchoService()
+    not_mine = Recipient(
+        recipient_id="r-1",
+        user_id="someone-else",  # wrong owner
+        name="X",
+        email="x@e.com",
+        profile_image_url="https://b.s3.amazonaws.com/p/r1.jpg",
+    )
+    echoes = [Echo(echo_id="e-1", user_id="u-1", title="t", recipient_id="r-1")]
+
+    sign_calls: list[str] = []
+
+    async def fake_sign(url):
+        sign_calls.append(url)
+        return f"signed::{url}"
+
+    with patch.object(
+        svc,
+        "_batch_get_recipients",
+        new=AsyncMock(return_value={"r-1": not_mine}),
+    ):
+        with patch.object(svc, "_sign_profile_url", side_effect=fake_sign):
+            await svc._enrich_echoes_with_recipients(echoes, owner_user_id="u-1")
+
+    assert sign_calls == [], "must not sign foreign-owner profile URLs"
+    assert echoes[0].recipient is None


### PR DESCRIPTION
…ist URLs

- _sign_profile_urls helper: dedupes a set of profile URLs and signs each distinct one once via asyncio.gather.
- _enrich_echoes_with_recipients + get_user_recipients + get_user_guardians use it. Per-page profile-sign latency drops from O(N) serial to O(distinct) parallel.
- get_user_echoes: stop calling _sign_media_url (route response already omits media_url, the signing was pure waste).
- _sign_media_url: TTL 1h -> 6h. Users locking phone with player open no longer come back to 403s.
- GET /api/echoes/inbox: drop media_url from response. Inbox card uses only echo_id / echo_type / title / sender / category / scheduled_at / created_at; playback screens fetch detail-by-id which signs the URL. Closes the regression PR1's bucket lockdown would have produced.

Tests: 7 new in tests/test_echo_pull_tier_1.py. Full suite: 614 passed (clean main 608 + 6 net new). mypy clean on changed files.