### PR TITLE
perf(api): idempotency-key support on echo create + finalize-media

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -38,6 +38,10 @@ provider:
     DYNAMODB_ECHOES_TABLE: ${self:service}-echoes-${self:provider.stage}
     DYNAMODB_RECIPIENTS_TABLE: ${self:service}-recipients-${self:provider.stage}
     DYNAMODB_GUARDIANS_TABLE: ${self:service}-guardians-${self:provider.stage}
+    # Stores cached responses keyed by client-supplied Idempotency-Key.
+    # Read on every write that supports idempotency; written with a 24 h
+    # TTL via the table's expires_at attribute.
+    DYNAMODB_IDEMPOTENCY_TABLE: ${self:service}-idempotency-${self:provider.stage}
     ECHO_MEDIA_BUCKET: mirror-collective-vault-storage-${self:provider.stage}
     # Route S3 PUTs through the s3-accelerate endpoint. Requires the bucket's
     # AccelerateConfiguration to be Enabled (see resources section). See
@@ -121,6 +125,8 @@ provider:
               - '/'
               - - Fn::GetAtt: [ EchoVaultGuardiansTable, Arn ]
                 - 'index/*'
+            # Idempotency cache — single-PK, no GSIs.
+            - Fn::GetAtt: [ IdempotencyTable, Arn ]
             # Subscription Tables
             - Fn::GetAtt: [ SubscriptionsTable, Arn ]
             - Fn::Join:
@@ -682,6 +688,27 @@ resources:
                 KeyType: HASH
             Projection:
               ProjectionType: ALL
+
+    IdempotencyTable:
+      Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
+      UpdateReplacePolicy: Retain
+      Properties:
+        TableName: ${self:provider.environment.DYNAMODB_IDEMPOTENCY_TABLE}
+        BillingMode: PAY_PER_REQUEST
+        AttributeDefinitions:
+          # Composite PK: "<user_id>|<route>|<client_key>" keeps the
+          # per-user / per-route namespacing flat for a single HASH lookup.
+          - AttributeName: key_namespace
+            AttributeType: S
+        KeySchema:
+          - AttributeName: key_namespace
+            KeyType: HASH
+        # TTL on epoch-seconds attribute — DynamoDB deletes within 48h of
+        # the timestamp passing. Set to created_at + 24h by the writer.
+        TimeToLiveSpecification:
+          AttributeName: expires_at
+          Enabled: true
 
     EchoVaultMediaBucket:
       Type: AWS::S3::Bucket

--- a/src/app/api/echo_routes.py
+++ b/src/app/api/echo_routes.py
@@ -6,9 +6,10 @@ Endpoints for managing Echoes, Recipients, and Guardians.
 import logging
 from typing import Any, Dict, List, Literal, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, EmailStr, validator
 
+from ..core.idempotency import idempotent
 from ..core.security import get_current_user
 from ..services.echo_service import get_echo_service
 from ..services.email_service import email_service
@@ -211,14 +212,22 @@ class GuardianResponse(BaseModel):
 
 
 @router.post("/echoes", response_model=Dict[str, Any], status_code=201)
+@idempotent(route_id="create_echo")
 async def create_echo(
-    request: CreateEchoRequest,
+    payload: CreateEchoRequest,
+    request: Request,
     current_user: Dict[str, Any] = Depends(get_current_user),
 ):
-    """Create a new echo in the vault."""
+    """Create a new echo in the vault.
+
+    Idempotency: when the client sends an ``Idempotency-Key`` header,
+    duplicate requests with the same key from the same user return the
+    original response within 24 h. Lets clients safely retry after a
+    network timeout without producing duplicate vault rows.
+    """
     user_id = current_user["id"]
 
-    echo = await echo_service.create_echo(user_id, request.model_dump())
+    echo = await echo_service.create_echo(user_id, payload.model_dump())
 
     return {
         "success": True,
@@ -261,9 +270,11 @@ async def get_upload_url(
 
 
 @router.post("/echoes/{echo_id}/finalize-media", response_model=Dict[str, Any])
+@idempotent(route_id="finalize_media")
 async def finalize_media_upload(
     echo_id: str,
-    request: FinalizeMediaRequest,
+    payload: FinalizeMediaRequest,
+    request: Request,
     current_user: Dict[str, Any] = Depends(get_current_user),
 ):
     """Verify a completed S3 PUT and atomically attach it to the echo.
@@ -275,6 +286,10 @@ async def finalize_media_upload(
 
     Returns the full updated echo (same shape as ``GET /echoes/{id}``)
     so clients can refresh their cached state without a follow-up read.
+
+    Idempotency: when the client sends an ``Idempotency-Key`` header,
+    duplicate finalize calls (e.g. after a network blip mid-response)
+    return the original response within 24 h.
     """
     from ..core.exceptions import NotFoundError, ValidationError
 
@@ -284,8 +299,8 @@ async def finalize_media_upload(
         echo = await echo_service.finalize_upload(
             echo_id=echo_id,
             user_id=user_id,
-            key=request.key,
-            content_type=request.content_type,
+            key=payload.key,
+            content_type=payload.content_type,
         )
     except NotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))

--- a/src/app/core/idempotency.py
+++ b/src/app/core/idempotency.py
@@ -1,0 +1,153 @@
+"""FastAPI decorator for idempotent write endpoints.
+
+Usage
+-----
+
+    from ..core.idempotency import idempotent
+
+    @router.post("/echoes")
+    @idempotent(route_id="create_echo")
+    async def create_echo(request: ..., current_user=...):
+        ...
+
+The decorator looks for ``Idempotency-Key`` on the incoming request.
+If present and a cached response exists for ``(user_id, route_id, key)``,
+the cached payload is returned verbatim — the route handler is never
+invoked. Otherwise the handler runs normally and its response is
+recorded under the key with a 24 h TTL.
+
+Why a decorator over middleware
+-------------------------------
+The middleware would have to identify which routes participate in
+idempotency, parse the user_id from a downstream auth dependency, and
+buffer the entire response body. A decorator sees the resolved
+``current_user`` cleanly and only the routes that explicitly opt in
+pay the cache round-trip.
+
+Contract details
+----------------
+- If the header is missing, the wrapper is a no-op (handler runs as-is).
+  Idempotency is opt-in per-call from the client, not server-enforced.
+- If the handler raises, nothing is cached — failures are not idempotent
+  by design. The client SHOULD retry a failure with the same key, and
+  the server WILL run the handler again (which is the correct behavior:
+  the first call's side effects never completed).
+- Only ``2xx`` responses are cached. Caching a 4xx would mask a genuine
+  validation failure on retry.
+- Keys are length-bounded (max 200 chars) to prevent abuse via giant
+  client keys.
+"""
+
+import functools
+import inspect
+import logging
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+from fastapi import HTTPException, Request
+
+from ..services.idempotency_service import get_idempotency_service
+
+logger = logging.getLogger(__name__)
+
+# Cap the client key length to keep DDB items small. Long keys are not
+# functional — clients should send a UUID, which is 36 chars.
+MAX_CLIENT_KEY_LEN = 200
+
+
+def _extract_client_key(request: Optional[Request]) -> Optional[str]:
+    """Pull the Idempotency-Key header off the request. Header names are
+    case-insensitive per RFC; FastAPI's mapping handles that. Returns
+    None if the header is missing or empty.
+    """
+    if request is None:
+        return None
+    key = request.headers.get("Idempotency-Key") or request.headers.get(
+        "idempotency-key"
+    )
+    if not key:
+        return None
+    key = key.strip()
+    if not key:
+        return None
+    if len(key) > MAX_CLIENT_KEY_LEN:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Idempotency-Key exceeds {MAX_CLIENT_KEY_LEN} chars",
+        )
+    return key
+
+
+def _extract_user_id(kwargs: Dict[str, Any]) -> Optional[str]:
+    """Pull user_id out of the resolved `current_user` dependency. The
+    auth dependency in this codebase puts the Cognito sub at
+    ``current_user['id']``.
+    """
+    cu = kwargs.get("current_user")
+    if not isinstance(cu, dict):
+        return None
+    user_id = cu.get("id")
+    return user_id if isinstance(user_id, str) and user_id else None
+
+
+def idempotent(route_id: str) -> Callable[..., Callable[..., Awaitable[Any]]]:
+    """Decorator factory; bind ``route_id`` per route.
+
+    The decorated handler must accept a ``request: Request`` parameter
+    (FastAPI's injection covers it automatically) and a ``current_user``
+    keyword argument from the auth dependency.
+    """
+
+    def decorator(
+        handler: Callable[..., Awaitable[Any]]
+    ) -> Callable[..., Awaitable[Any]]:
+        # Verify the decorated function exposes the Request parameter so
+        # FastAPI's dependency injection wires it for us.
+        sig = inspect.signature(handler)
+        has_request_param = "request" in sig.parameters
+
+        @functools.wraps(handler)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            request: Optional[Request] = (
+                kwargs.get("request") if has_request_param else None
+            )
+            client_key = _extract_client_key(request)
+            user_id = _extract_user_id(kwargs)
+
+            # If either is missing, fall through to the handler — the
+            # client didn't opt into idempotency or auth isn't ready.
+            if not client_key or not user_id:
+                return await handler(*args, **kwargs)
+
+            service = get_idempotency_service()
+
+            # Cache lookup.
+            cached = await service.get_cached(
+                user_id=user_id, route=route_id, client_key=client_key
+            )
+            if cached is not None:
+                logger.info(
+                    f"Idempotency HIT route={route_id} user={user_id} "
+                    f"key={client_key} status={cached['status_code']}"
+                )
+                return cached["body"]
+
+            # Cache miss — run the handler and capture its response.
+            response = await handler(*args, **kwargs)
+
+            # We only cache 2xx-ish responses. The handlers in this
+            # codebase return dicts on success and raise HTTPException
+            # on failure (which never reaches this point), so a
+            # successful return here is effectively a 2xx.
+            if isinstance(response, dict):
+                await service.cache(
+                    user_id=user_id,
+                    route=route_id,
+                    client_key=client_key,
+                    status_code=200,
+                    body=response,
+                )
+            return response
+
+        return wrapper
+
+    return decorator

--- a/src/app/services/idempotency_service.py
+++ b/src/app/services/idempotency_service.py
@@ -1,0 +1,208 @@
+"""Idempotency cache for write endpoints.
+
+Lets a client safely retry a POST without producing duplicate writes:
+
+1. Client sends an ``Idempotency-Key`` header (a UUID per logical request).
+2. Server checks the cache. On hit: returns the stored response verbatim.
+3. On miss: serves the request normally, then stores ``(status, body)``
+   under the key with a 24 h TTL.
+
+The cache key is namespaced ``"<user_id>|<route>|<client_key>"`` so that
+keys are scoped per-user + per-route — a client cannot pollute another
+user's namespace, and the same UUID can be reused across distinct routes
+without collision.
+
+Storage is the ``IdempotencyTable`` defined in ``serverless.yml`` (PK is
+``key_namespace``; TTL is ``expires_at`` epoch seconds, deleted within
+~48 h of the timestamp passing per the DynamoDB TTL contract).
+
+Design notes
+------------
+- Writes are conditional on the key NOT already existing
+  (``attribute_not_exists(key_namespace)``). If two concurrent requests
+  race, the second one's write fails harmlessly and the second client
+  gets a fresh response (acceptable — they raced and the server already
+  handled both). The next retry from either client sees the cached
+  result.
+- ``response_body`` is stored as a JSON-encoded string rather than a
+  native DynamoDB map so we don't have to round-trip type coercions
+  (Decimal ↔ float, etc.) — the API serialization is the source of
+  truth, and replaying it is byte-equivalent.
+"""
+
+import json
+import logging
+import os
+import time
+from contextlib import AsyncExitStack
+from typing import Any, Dict, Optional
+
+import aioboto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+
+# 24 hours. Long enough to cover all realistic client retry windows
+# (timeout + manual user retry) without keeping the table large. Tied
+# to the comment on DYNAMODB_IDEMPOTENCY_TABLE in serverless.yml; if
+# you tune this, update both.
+IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60
+
+
+def build_namespace(user_id: str, route: str, client_key: str) -> str:
+    """Build the composite cache key. Public for callers that want to
+    inspect or pre-compute it (e.g. tests).
+    """
+    return f"{user_id}|{route}|{client_key}"
+
+
+class IdempotencyService:
+    """Thin DDB wrapper for caching idempotent route responses.
+
+    Mirrors the long-lived-client pattern used by EchoService (aioboto3
+    resource cached in an AsyncExitStack for the lifetime of the Lambda
+    container).
+    """
+
+    def __init__(self) -> None:
+        self.region = os.getenv("AWS_REGION", "us-east-1")
+        self.table_name = os.getenv(
+            "DYNAMODB_IDEMPOTENCY_TABLE",
+            "mirror-collective-python-api-idempotency-development",
+        )
+        self.endpoint_url = os.getenv("DYNAMODB_ENDPOINT_URL")
+
+        self._session = aioboto3.Session()
+        self._exit_stack: Optional[AsyncExitStack] = None
+        self._dynamodb_resource: Any = None
+        self._boto_config = Config(
+            max_pool_connections=25,
+            retries={"max_attempts": 3, "mode": "adaptive"},
+        )
+
+    def _ddb_kwargs(self) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {
+            "region_name": self.region,
+            "config": self._boto_config,
+        }
+        if self.endpoint_url:
+            kwargs.update(
+                {
+                    "endpoint_url": self.endpoint_url,
+                    "aws_access_key_id": "dummy",
+                    "aws_secret_access_key": "dummy",
+                }
+            )
+        return kwargs
+
+    async def _get_resource(self) -> Any:
+        if self._dynamodb_resource is not None:
+            return self._dynamodb_resource
+        if self._exit_stack is None:
+            self._exit_stack = AsyncExitStack()
+            await self._exit_stack.__aenter__()
+        cm = self._session.resource("dynamodb", **self._ddb_kwargs())
+        self._dynamodb_resource = await self._exit_stack.enter_async_context(cm)
+        return self._dynamodb_resource
+
+    async def get_cached(
+        self,
+        user_id: str,
+        route: str,
+        client_key: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Return the previously-stored response for this key, or None.
+
+        Returns a dict ``{status_code: int, body: dict}`` ready for the
+        route handler to relay. ``None`` means cache miss (or expired
+        before DDB's TTL sweep ran — handled the same way).
+        """
+        ns = build_namespace(user_id, route, client_key)
+        try:
+            ddb = await self._get_resource()
+            table = await ddb.Table(self.table_name)
+            response = await table.get_item(Key={"key_namespace": ns})
+        except ClientError as e:
+            # Don't fail the user's request because the cache is sick.
+            # Idempotency is opportunistic — the route handler will run
+            # again as if there were no cache.
+            logger.error(f"Idempotency get_item failed for {ns}: {e}")
+            return None
+
+        item = response.get("Item")
+        if not item:
+            return None
+
+        # Honor expires_at even if DDB hasn't pruned yet — the TTL sweep
+        # runs every ~48 h, not on access. A late retry against an
+        # already-stale entry shouldn't replay.
+        expires_at = int(item.get("expires_at") or 0)
+        if expires_at and expires_at <= int(time.time()):
+            return None
+
+        raw_body = item.get("response_body")
+        try:
+            body = json.loads(raw_body) if raw_body else {}
+        except (TypeError, ValueError):
+            # Corrupt cache row — treat as miss so the route can serve
+            # fresh. The next write will overwrite this row.
+            logger.warning(f"Idempotency row {ns} has malformed body; treating as miss")
+            return None
+
+        return {
+            "status_code": int(item.get("status_code") or 200),
+            "body": body,
+        }
+
+    async def cache(
+        self,
+        user_id: str,
+        route: str,
+        client_key: str,
+        status_code: int,
+        body: Dict[str, Any],
+    ) -> None:
+        """Store the response under the key. No-op on race (concurrent
+        write of the same key).
+        """
+        ns = build_namespace(user_id, route, client_key)
+        now = int(time.time())
+        item = {
+            "key_namespace": ns,
+            "user_id": user_id,
+            "route": route,
+            "client_key": client_key,
+            "status_code": int(status_code),
+            "response_body": json.dumps(body, default=str),
+            "created_at": now,
+            "expires_at": now + IDEMPOTENCY_TTL_SECONDS,
+        }
+        try:
+            ddb = await self._get_resource()
+            table = await ddb.Table(self.table_name)
+            await table.put_item(
+                Item=item,
+                ConditionExpression="attribute_not_exists(key_namespace)",
+            )
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code == "ConditionalCheckFailedException":
+                # Two requests with the same key landed in parallel.
+                # The first one's write wins; the second is harmless.
+                logger.info(f"Idempotency race resolved for {ns}")
+                return
+            logger.error(f"Idempotency put_item failed for {ns}: {e}")
+            # Same opportunistic-failure posture as get_cached.
+
+
+_SINGLETON: Optional[IdempotencyService] = None
+
+
+def get_idempotency_service() -> IdempotencyService:
+    """Module-level singleton — mirror EchoService's lazy pattern."""
+    global _SINGLETON
+    if _SINGLETON is None:
+        _SINGLETON = IdempotencyService()
+    return _SINGLETON

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -1,0 +1,357 @@
+"""Tests for the idempotency cache.
+
+Covers:
+- IdempotencyService.get_cached: miss / hit / expired / corrupt-body /
+  DDB failure.
+- IdempotencyService.cache: write succeeds, race resolved (Conditional
+  Check), DDB failure absorbed.
+- @idempotent decorator: no header → handler runs; header + cache miss
+  → handler runs and result is stored; header + cache hit → handler
+  skipped; oversize key → 400; non-dict response not cached.
+"""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from src.app.core.idempotency import idempotent
+from src.app.services.idempotency_service import (
+    IDEMPOTENCY_TTL_SECONDS,
+    IdempotencyService,
+    build_namespace,
+)
+
+
+def _ddb_resource_mock(get_item_return=None, put_item_side_effect=None):
+    table = AsyncMock()
+    if get_item_return is not None:
+        table.get_item = AsyncMock(return_value=get_item_return)
+    else:
+        table.get_item = AsyncMock(return_value={})
+    if put_item_side_effect is not None:
+        table.put_item = AsyncMock(side_effect=put_item_side_effect)
+    else:
+        table.put_item = AsyncMock()
+    resource = AsyncMock()
+    resource.Table = AsyncMock(return_value=table)
+    return resource, table
+
+
+# ---------------------------------------------------------------------
+# build_namespace
+# ---------------------------------------------------------------------
+
+
+def test_build_namespace_includes_user_route_and_key():
+    ns = build_namespace("u-1", "create_echo", "abc-123")
+    assert ns == "u-1|create_echo|abc-123"
+
+
+# ---------------------------------------------------------------------
+# IdempotencyService.get_cached
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_cached_miss_returns_none():
+    svc = IdempotencyService()
+    resource, _ = _ddb_resource_mock(get_item_return={})
+    with patch.object(svc, "_get_resource", new=AsyncMock(return_value=resource)):
+        result = await svc.get_cached("u", "create_echo", "k")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_cached_hit_returns_status_and_body():
+    svc = IdempotencyService()
+    future = int(time.time()) + 1000
+    resource, _ = _ddb_resource_mock(
+        get_item_return={
+            "Item": {
+                "key_namespace": "u|create_echo|k",
+                "status_code": 200,
+                "response_body": '{"echo_id":"e-1"}',
+                "expires_at": future,
+            }
+        }
+    )
+    with patch.object(svc, "_get_resource", new=AsyncMock(return_value=resource)):
+        result = await svc.get_cached("u", "create_echo", "k")
+    assert result == {"status_code": 200, "body": {"echo_id": "e-1"}}
+
+
+@pytest.mark.asyncio
+async def test_get_cached_treats_expired_row_as_miss():
+    """DDB's TTL sweep is async, so an item with expires_at in the past
+    can still be returned by get_item. The service must filter those.
+    """
+    svc = IdempotencyService()
+    past = int(time.time()) - 10
+    resource, _ = _ddb_resource_mock(
+        get_item_return={
+            "Item": {
+                "key_namespace": "u|create_echo|k",
+                "status_code": 200,
+                "response_body": '{"x":1}',
+                "expires_at": past,
+            }
+        }
+    )
+    with patch.object(svc, "_get_resource", new=AsyncMock(return_value=resource)):
+        result = await svc.get_cached("u", "create_echo", "k")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_cached_corrupt_body_returns_none():
+    svc = IdempotencyService()
+    future = int(time.time()) + 1000
+    resource, _ = _ddb_resource_mock(
+        get_item_return={
+            "Item": {
+                "key_namespace": "u|create_echo|k",
+                "status_code": 200,
+                "response_body": "this-is-not-json{{",
+                "expires_at": future,
+            }
+        }
+    )
+    with patch.object(svc, "_get_resource", new=AsyncMock(return_value=resource)):
+        result = await svc.get_cached("u", "create_echo", "k")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_cached_swallows_ddb_failure():
+    """Cache failures must NOT propagate — idempotency is opportunistic."""
+    svc = IdempotencyService()
+    table = AsyncMock()
+    table.get_item = AsyncMock(
+        side_effect=ClientError({"Error": {"Code": "InternalServerError"}}, "GetItem")
+    )
+    resource = AsyncMock()
+    resource.Table = AsyncMock(return_value=table)
+    with patch.object(svc, "_get_resource", new=AsyncMock(return_value=resource)):
+        result = await svc.get_cached("u", "create_echo", "k")
+    assert result is None
+
+
+# ---------------------------------------------------------------------
+# IdempotencyService.cache
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_writes_with_24h_ttl():
+    svc = IdempotencyService()
+    resource, table = _ddb_resource_mock()
+    with patch.object(svc, "_get_resource", new=AsyncMock(return_value=resource)):
+        await svc.cache(
+            user_id="u",
+            route="create_echo",
+            client_key="k",
+            status_code=200,
+            body={"echo_id": "e-1"},
+        )
+    table.put_item.assert_awaited_once()
+    args, _ = table.put_item.call_args.args, table.put_item.call_args.kwargs
+    item = table.put_item.call_args.kwargs["Item"]
+    assert item["key_namespace"] == "u|create_echo|k"
+    assert item["status_code"] == 200
+    assert item["response_body"] == '{"echo_id": "e-1"}'
+    # expires_at is roughly now + 24 h.
+    assert item["expires_at"] - item["created_at"] == IDEMPOTENCY_TTL_SECONDS
+    # ConditionExpression enforces first-writer-wins.
+    assert (
+        "attribute_not_exists" in table.put_item.call_args.kwargs["ConditionExpression"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_cache_swallows_conditional_check_failure():
+    """Two requests race with the same key — second write's
+    ConditionalCheckFailed is the expected outcome, not an error.
+    """
+    svc = IdempotencyService()
+    resource, _ = _ddb_resource_mock(
+        put_item_side_effect=ClientError(
+            {"Error": {"Code": "ConditionalCheckFailedException"}}, "PutItem"
+        )
+    )
+    with patch.object(svc, "_get_resource", new=AsyncMock(return_value=resource)):
+        # Should NOT raise.
+        await svc.cache("u", "create_echo", "k", 200, {"x": 1})
+
+
+@pytest.mark.asyncio
+async def test_cache_swallows_unexpected_ddb_error():
+    svc = IdempotencyService()
+    resource, _ = _ddb_resource_mock(
+        put_item_side_effect=ClientError(
+            {"Error": {"Code": "ProvisionedThroughputExceededException"}},
+            "PutItem",
+        )
+    )
+    with patch.object(svc, "_get_resource", new=AsyncMock(return_value=resource)):
+        # Should NOT raise — caching is opportunistic.
+        await svc.cache("u", "create_echo", "k", 200, {"x": 1})
+
+
+# ---------------------------------------------------------------------
+# @idempotent decorator
+# ---------------------------------------------------------------------
+
+
+class _FakeRequest:
+    """Minimal stand-in for starlette.Request — only headers are read."""
+
+    def __init__(self, headers=None):
+        self.headers = headers or {}
+
+
+@pytest.mark.asyncio
+async def test_decorator_no_header_runs_handler_normally():
+    calls = []
+
+    @idempotent(route_id="x")
+    async def handler(*, request, current_user):
+        calls.append("ran")
+        return {"ok": True}
+
+    result = await handler(
+        request=_FakeRequest(headers={}),
+        current_user={"id": "u-1"},
+    )
+    assert calls == ["ran"]
+    assert result == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_decorator_oversize_key_returns_400():
+    from fastapi import HTTPException
+
+    @idempotent(route_id="x")
+    async def handler(*, request, current_user):
+        return {"ok": True}
+
+    long_key = "a" * 201
+    with pytest.raises(HTTPException) as exc_info:
+        await handler(
+            request=_FakeRequest(headers={"Idempotency-Key": long_key}),
+            current_user={"id": "u-1"},
+        )
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_decorator_cache_hit_skips_handler_and_returns_cached_body():
+    """Cache hit: handler must NOT run."""
+    calls = []
+
+    @idempotent(route_id="x")
+    async def handler(*, request, current_user):
+        calls.append("ran")
+        return {"ok": True, "fresh": True}
+
+    fake_service = MagicMock()
+    fake_service.get_cached = AsyncMock(
+        return_value={"status_code": 200, "body": {"ok": True, "cached": True}}
+    )
+    fake_service.cache = AsyncMock()
+
+    with patch(
+        "src.app.core.idempotency.get_idempotency_service",
+        return_value=fake_service,
+    ):
+        result = await handler(
+            request=_FakeRequest(headers={"Idempotency-Key": "k1"}),
+            current_user={"id": "u-1"},
+        )
+
+    assert calls == [], "handler must not run on cache hit"
+    assert result == {"ok": True, "cached": True}
+    fake_service.cache.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_decorator_cache_miss_runs_handler_and_stores_response():
+    calls = []
+
+    @idempotent(route_id="x")
+    async def handler(*, request, current_user):
+        calls.append("ran")
+        return {"ok": True}
+
+    fake_service = MagicMock()
+    fake_service.get_cached = AsyncMock(return_value=None)
+    fake_service.cache = AsyncMock()
+
+    with patch(
+        "src.app.core.idempotency.get_idempotency_service",
+        return_value=fake_service,
+    ):
+        result = await handler(
+            request=_FakeRequest(headers={"Idempotency-Key": "k1"}),
+            current_user={"id": "u-1"},
+        )
+
+    assert calls == ["ran"]
+    assert result == {"ok": True}
+    fake_service.cache.assert_awaited_once()
+    cache_kwargs = fake_service.cache.call_args.kwargs
+    assert cache_kwargs["user_id"] == "u-1"
+    assert cache_kwargs["route"] == "x"
+    assert cache_kwargs["client_key"] == "k1"
+    assert cache_kwargs["body"] == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_decorator_no_user_in_kwargs_passes_through():
+    """If the handler isn't using the standard auth dependency (e.g.
+    public endpoint with the decorator accidentally applied), the
+    decorator must not crash — just pass through.
+    """
+    calls = []
+
+    @idempotent(route_id="x")
+    async def handler(*, request, current_user):
+        calls.append("ran")
+        return {"ok": True}
+
+    # current_user empty / no id.
+    result = await handler(
+        request=_FakeRequest(headers={"Idempotency-Key": "k1"}),
+        current_user={},
+    )
+    assert calls == ["ran"]
+    assert result == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_decorator_does_not_cache_non_dict_responses():
+    """Handler returning a non-dict (e.g. a Response object) should be
+    passed through but NOT cached — we don't have a way to serialize
+    those into the cache row.
+    """
+
+    @idempotent(route_id="x")
+    async def handler(*, request, current_user):
+        return "not-a-dict"
+
+    fake_service = MagicMock()
+    fake_service.get_cached = AsyncMock(return_value=None)
+    fake_service.cache = AsyncMock()
+
+    with patch(
+        "src.app.core.idempotency.get_idempotency_service",
+        return_value=fake_service,
+    ):
+        result = await handler(
+            request=_FakeRequest(headers={"Idempotency-Key": "k1"}),
+            current_user={"id": "u-1"},
+        )
+
+    assert result == "not-a-dict"
+    fake_service.cache.assert_not_called()


### PR DESCRIPTION
Lets clients safely retry a POST after a network timeout without producing duplicate vault rows or split-brain finalize states.

- New IdempotencyTable (PK key_namespace; TTL 24h on expires_at).
- IdempotencyService.get_cached / cache with conditional-put for first-writer-wins (concurrent dupes resolve without 5xx).
- @idempotent(route_id=...) decorator reads the Idempotency-Key header, returns cached payload on hit, runs + records on miss. Pass-through when header is absent (opt-in per call).
- Wired into POST /api/echoes and POST /api/echoes/{id}/finalize-media.
- Hardening: oversize keys (>200) → 400; corrupt cached body treated as miss; DDB failures swallowed (cache is opportunistic).
- 15 new tests; full suite 660 passed. mypy clean.

Frontend leg lands in a follow-up PR.