### PR TITLE
perf(upload): S3 multipart upload routes for files >50 MB

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -732,6 +732,21 @@ resources:
           BlockPublicPolicy: true
           IgnorePublicAcls: true
           RestrictPublicBuckets: true
+        # Reap abandoned multipart uploads. The client SHOULD call
+        # POST /echoes/{id}/multipart/abort when the user cancels, but
+        # we can't trust that — a backgrounded app may never get the
+        # chance. Without this rule, partial uploads sit in S3
+        # consuming storage until manually cleaned up.
+        # 7 days is comfortably longer than any real upload window
+        # (largest current allowed file size + worst-case cellular
+        # ≪ 24 h) but short enough to keep the orphan storage bill
+        # bounded.
+        LifecycleConfiguration:
+          Rules:
+            - Id: AbortIncompleteMultipartUpload
+              Status: Enabled
+              AbortIncompleteMultipartUpload:
+                DaysAfterInitiation: 7
         CorsConfiguration:
           CorsRules:
             - AllowedHeaders: ['*']

--- a/src/app/api/echo_routes.py
+++ b/src/app/api/echo_routes.py
@@ -148,6 +148,53 @@ class FinalizeMediaRequest(BaseModel):
     content_type: Optional[str] = None  # caller hint, overridden by S3 HEAD
 
 
+class MultipartInitiateRequest(BaseModel):
+    """Start an S3 multipart upload for a >50 MB file."""
+
+    file_type: str  # MIME type — validated against the allowlist
+
+
+class MultipartPartUrlsRequest(BaseModel):
+    """Ask for presigned PUT URLs for a batch of part numbers.
+
+    The client typically asks in batches of 4-8 (matching its upload
+    concurrency) so the backend response stays small.
+    """
+
+    upload_id: str
+    key: str
+    # 1-indexed part numbers. S3 hard cap is 10,000; service-side
+    # validation rejects out-of-range values. Service also caps batch size.
+    part_numbers: List[int]
+
+
+class CompletedPart(BaseModel):
+    """An uploaded part as reported by the client.
+
+    ETag comes from S3's per-part PUT response header. The service
+    accepts both quoted (S3's wire format) and unquoted forms — the
+    quoting is canonicalized before the CompleteMultipartUpload call.
+    """
+
+    part_number: int
+    etag: str
+
+
+class MultipartCompleteRequest(BaseModel):
+    """Finalize the multipart upload + commit media_url to the echo row."""
+
+    upload_id: str
+    key: str
+    parts: List[CompletedPart]
+
+
+class MultipartAbortRequest(BaseModel):
+    """Best-effort cancel of an in-progress multipart upload."""
+
+    upload_id: str
+    key: str
+
+
 class CreateRecipientRequest(BaseModel):
     name: str
     email: EmailStr
@@ -327,6 +374,185 @@ async def finalize_media_upload(
         },
         "message": "Echo media finalized",
     }
+
+
+# ========================================
+# MULTIPART UPLOAD ROUTES (>50 MB files)
+# ========================================
+#
+# Four-step ceremony around S3's MultipartUpload API. Compared to the
+# single-PUT presign in /echoes/upload-url:
+#
+#   - resilient: a failed part retries individually instead of throwing
+#     the whole upload away.
+#   - parallel: the client uploads N parts at once, capped only by its
+#     own concurrency setting (typically 4).
+#
+# The route surface mirrors S3's: initiate → part-urls → complete.
+# abort is the cleanup path for client-side give-ups. The backend's
+# bucket-lifecycle rule reaps abandoned uploads after 7 days as a
+# defense-in-depth backstop.
+
+
+@router.post("/echoes/{echo_id}/multipart/initiate", response_model=Dict[str, Any])
+@idempotent(route_id="multipart_initiate")
+async def initiate_multipart_upload(
+    echo_id: str,
+    payload: MultipartInitiateRequest,
+    request: Request,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """Open a multipart upload session for this echo.
+
+    Returns ``{upload_id, key, bucket}``. The client uses ``upload_id``
+    on every subsequent multipart call.
+
+    Idempotent: clients that retry through the BaseApiService 429 loop
+    will get the same upload_id back rather than opening duplicate
+    upload sessions (which would each tie up storage until reaped by
+    the lifecycle rule).
+    """
+    from ..core.exceptions import NotFoundError, ValidationError
+
+    user_id = current_user["id"]
+    try:
+        result = await echo_service.initiate_multipart_upload(
+            echo_id=echo_id,
+            user_id=user_id,
+            file_type=payload.file_type,
+        )
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return {
+        "success": True,
+        "data": result,
+        "message": "Multipart upload initiated",
+    }
+
+
+@router.post("/echoes/{echo_id}/multipart/part-urls", response_model=Dict[str, Any])
+async def get_multipart_part_urls(
+    echo_id: str,
+    payload: MultipartPartUrlsRequest,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """Generate presigned PUT URLs for a batch of part numbers.
+
+    NOT decorated with @idempotent — these are URL-generation calls and
+    caching them would hand back stale signatures after the original
+    presign expired. Clients can safely call this again to refresh URLs.
+    """
+    from ..core.exceptions import NotFoundError, ValidationError
+
+    user_id = current_user["id"]
+    try:
+        urls = await echo_service.generate_multipart_part_urls(
+            echo_id=echo_id,
+            user_id=user_id,
+            upload_id=payload.upload_id,
+            key=payload.key,
+            part_numbers=payload.part_numbers,
+        )
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return {
+        "success": True,
+        "data": {"part_urls": urls},
+        "message": "Part URLs generated",
+    }
+
+
+@router.post("/echoes/{echo_id}/multipart/complete", response_model=Dict[str, Any])
+@idempotent(route_id="multipart_complete")
+async def complete_multipart_upload(
+    echo_id: str,
+    payload: MultipartCompleteRequest,
+    request: Request,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """Assemble the parts in S3 and commit media_url atomically.
+
+    Returns the full updated echo (same shape as GET /echoes/{id}).
+
+    Idempotent: a network blip between S3 complete and the response
+    can leave the client retrying. Caching the response lets the
+    retry return the same echo state without a second S3 complete
+    (which would 404 — the upload session is already gone).
+    """
+    from ..core.exceptions import NotFoundError, ValidationError
+
+    user_id = current_user["id"]
+    parts_dicts = [
+        {"part_number": p.part_number, "etag": p.etag} for p in payload.parts
+    ]
+    try:
+        echo = await echo_service.complete_multipart_upload(
+            echo_id=echo_id,
+            user_id=user_id,
+            upload_id=payload.upload_id,
+            key=payload.key,
+            parts=parts_dicts,
+        )
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return {
+        "success": True,
+        "data": {
+            "echo_id": echo.echo_id,
+            "title": echo.title,
+            "category": echo.category,
+            "echo_type": echo.echo_type.value,
+            "status": echo.status.value,
+            "content": echo.content,
+            "media_url": echo.media_url,
+            "recipient_id": echo.recipient_id,
+            "recipient": echo.recipient,
+            "release_date": echo.release_date,
+            "lock_date": echo.lock_date,
+            "letter_to_recipient": echo.letter_to_recipient,
+            "created_at": echo.created_at,
+            "updated_at": echo.updated_at,
+        },
+        "message": "Multipart upload completed",
+    }
+
+
+@router.post("/echoes/{echo_id}/multipart/abort", response_model=Dict[str, Any])
+async def abort_multipart_upload(
+    echo_id: str,
+    payload: MultipartAbortRequest,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """Cancel an in-progress multipart upload.
+
+    Idempotent by nature (NoSuchUpload is treated as success at the
+    service layer), so no @idempotent decorator needed.
+    """
+    from ..core.exceptions import NotFoundError, ValidationError
+
+    user_id = current_user["id"]
+    try:
+        await echo_service.abort_multipart_upload(
+            echo_id=echo_id,
+            user_id=user_id,
+            upload_id=payload.upload_id,
+            key=payload.key,
+        )
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return {"success": True, "message": "Multipart upload aborted"}
 
 
 @router.get("/echoes", response_model=Dict[str, Any])

--- a/src/app/services/echo_service.py
+++ b/src/app/services/echo_service.py
@@ -1551,6 +1551,349 @@ class EchoService:
         )
         return echo
 
+    # ========================================
+    # MULTIPART UPLOAD (>50 MB files)
+    # ========================================
+    #
+    # The single-PUT presigned URL path works for everything up to ~5 GB,
+    # but in practice files above ~50 MB on cellular hit two problems:
+    #
+    # 1. A single TCP connection failing somewhere mid-upload throws away
+    #    everything uploaded so far. With multipart, only the failed
+    #    chunk retries.
+    # 2. We can't upload parts in parallel, so wall-clock time is
+    #    bottlenecked by single-connection bandwidth even when the link
+    #    can carry more.
+    #
+    # The four methods below wrap S3's multipart-upload API:
+    #   - initiate_multipart_upload: creates the upload, returns upload_id.
+    #   - generate_multipart_part_urls: presigns one URL per part.
+    #   - complete_multipart_upload: assembles the parts + atomically
+    #     commits media_url (reuses finalize_upload's HEAD + DDB write).
+    #   - abort_multipart_upload: cleans up on client-side error.
+    #
+    # Abandoned uploads are also reaped by the bucket-level
+    # LifecycleConfiguration in serverless.yml (7-day TTL) so a misbehaving
+    # client can't run up storage charges by leaving partial uploads
+    # behind.
+
+    # 1-indexed; S3 hard cap is 10000.
+    MULTIPART_MAX_PART_NUMBER = 10_000
+    # Cap how many presigned URLs we hand out per call. The client's
+    # default 5 MB part size with parallelism=4 only needs a handful at
+    # a time; large batches just bloat the response. The client can
+    # always re-request more.
+    MULTIPART_PART_URL_BATCH_MAX = 1000
+
+    async def initiate_multipart_upload(
+        self,
+        echo_id: str,
+        user_id: str,
+        file_type: str,
+    ) -> Dict[str, Any]:
+        """Open an S3 multipart upload for the given echo.
+
+        Reuses the same key/metadata/tagging contract as the single-PUT
+        ``generate_upload_url`` so finalize semantics are uniform: the
+        bytes end up at the same canonical URL regardless of which
+        upload path produced them.
+
+        Raises:
+            NotFoundError: Echo doesn't exist or isn't owned by ``user_id``.
+            ValidationError: ``file_type`` isn't allowlisted, or the echo
+                already has media attached.
+        """
+        if file_type not in ALLOWED_UPLOAD_MIME_TYPES:
+            raise ValidationError(
+                f"Unsupported media type '{file_type}'. "
+                f"Allowed: {sorted(ALLOWED_UPLOAD_MIME_TYPES)}"
+            )
+
+        echo = await self.get_echo(echo_id, user_id)
+        if not echo:
+            raise NotFoundError(f"Echo {echo_id} not found")
+        if echo.user_id != user_id:
+            # NotFound, not Validation — avoid info leakage on echo
+            # existence to non-owners (same posture as finalize_upload).
+            logger.warning(
+                f"initiate_multipart owner reject: caller={user_id} "
+                f"owner={echo.user_id} echo={echo_id}"
+            )
+            raise NotFoundError(f"Echo {echo_id} not found")
+        if echo.media_url:
+            raise ValidationError("Echo media has already been finalized")
+
+        # Determine extension — same logic as the single-PUT path.
+        audio_map = {
+            "audio/m4a": "m4a",
+            "audio/mp4": "m4a",
+            "audio/aac": "aac",
+            "audio/mpeg": "mp3",
+        }
+        image_map = {
+            "image/jpeg": "jpg",
+            "image/png": "png",
+            "image/webp": "webp",
+            "image/heic": "heic",
+        }
+        if file_type in audio_map:
+            extension = audio_map[file_type]
+        elif file_type in image_map:
+            extension = image_map[file_type]
+        elif "video" in file_type:
+            extension = "mp4"
+        else:
+            extension = "mp4"
+
+        timestamp_iso = _current_timestamp()
+        timestamp_compact = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+        key = f"echoes/{user_id}/{echo_id}_{timestamp_compact}.{extension}"
+
+        tagging = "&".join(
+            [
+                f"user_id={user_id}",
+                f"echo_id={echo_id}",
+                "upload_type=echo",
+            ]
+        )
+        metadata = {
+            "user_id": user_id,
+            "echo_id": echo_id,
+            "upload_type": "echo",
+            "signed_at": timestamp_iso,
+        }
+
+        try:
+            s3 = await self._get_s3_client()
+            response = await s3.create_multipart_upload(
+                Bucket=self.s3_bucket,
+                Key=key,
+                ContentType=file_type,
+                CacheControl=_PUT_CACHE_CONTROL,
+                Tagging=tagging,
+                Metadata=metadata,
+            )
+        except ClientError as e:
+            logger.error(f"S3 create_multipart_upload failed for {key}: {e}")
+            raise InternalServerError(f"Failed to initiate multipart upload: {str(e)}")
+
+        upload_id = response["UploadId"]
+        logger.info(
+            f"Initiated multipart upload echo={echo_id} key={key} "
+            f"upload_id={upload_id[:12]}..."
+        )
+        return {
+            "upload_id": upload_id,
+            "key": key,
+            "bucket": self.s3_bucket,
+        }
+
+    async def generate_multipart_part_urls(
+        self,
+        echo_id: str,
+        user_id: str,
+        upload_id: str,
+        key: str,
+        part_numbers: List[int],
+    ) -> List[Dict[str, Any]]:
+        """Issue presigned PUT URLs for the requested part numbers.
+
+        Done in parallel via asyncio.gather — presign is local HMAC, so
+        the wins are smaller than for IO-bound calls, but a 1000-part
+        batch still cuts ~30 ms of awaited overhead.
+
+        Raises:
+            NotFoundError: echo doesn't exist / not owned.
+            ValidationError: key doesn't belong to this echo, part_numbers
+                empty, out of range, or batch larger than allowed.
+        """
+        if not part_numbers:
+            raise ValidationError("part_numbers cannot be empty")
+        if len(part_numbers) > self.MULTIPART_PART_URL_BATCH_MAX:
+            raise ValidationError(
+                f"part_numbers batch exceeds {self.MULTIPART_PART_URL_BATCH_MAX}"
+            )
+        for n in part_numbers:
+            if not isinstance(n, int) or n < 1 or n > self.MULTIPART_MAX_PART_NUMBER:
+                raise ValidationError(
+                    f"part_number {n} out of range [1, {self.MULTIPART_MAX_PART_NUMBER}]"
+                )
+
+        # Same ownership + tenancy checks as finalize_upload. The
+        # multipart-upload-id provided by S3 isn't user-scoped on its own
+        # — without this guard a caller could supply someone else's
+        # upload_id and start uploading parts to it.
+        echo = await self.get_echo(echo_id, user_id)
+        if not echo:
+            raise NotFoundError(f"Echo {echo_id} not found")
+        if echo.user_id != user_id:
+            raise NotFoundError(f"Echo {echo_id} not found")
+        expected_prefix = f"echoes/{user_id}/{echo_id}_"
+        if not key.startswith(expected_prefix):
+            logger.warning(
+                f"multipart_part_urls tenancy reject: user={user_id} "
+                f"echo={echo_id} key={key!r}"
+            )
+            raise ValidationError("Object key does not belong to this echo")
+
+        try:
+            s3 = await self._get_s3_client()
+            urls = await asyncio.gather(
+                *[
+                    s3.generate_presigned_url(
+                        "upload_part",
+                        Params={
+                            "Bucket": self.s3_bucket,
+                            "Key": key,
+                            "UploadId": upload_id,
+                            "PartNumber": n,
+                        },
+                        ExpiresIn=self.presigned_url_expiry,
+                    )
+                    for n in part_numbers
+                ]
+            )
+        except ClientError as e:
+            logger.error(f"S3 presign upload_part failed for {key}: {e}")
+            raise InternalServerError(f"Failed to generate part URLs: {str(e)}")
+
+        return [{"part_number": n, "url": u} for n, u in zip(part_numbers, urls)]
+
+    async def complete_multipart_upload(
+        self,
+        echo_id: str,
+        user_id: str,
+        upload_id: str,
+        key: str,
+        parts: List[Dict[str, Any]],
+    ) -> Echo:
+        """Finalize a multipart upload and atomically commit ``media_url``.
+
+        ``parts`` is the list of ``{"part_number": int, "etag": str}``
+        dicts the client collected from the per-part PUT response
+        headers. S3 requires them sorted by PartNumber ascending; we
+        sort defensively so a misordered client doesn't 400 on the
+        CompleteMultipartUpload call.
+
+        After S3 assembles the object we delegate to ``finalize_upload``
+        which runs the same HEAD + DDB-commit path as the single-PUT
+        flow. That keeps the post-upload state machine uniform.
+
+        Raises:
+            NotFoundError: echo doesn't exist / not owned.
+            ValidationError: key doesn't belong, parts list empty,
+                malformed, or out of part-number range.
+            InternalServerError: S3 complete failed (e.g. parts size
+                under 5 MB except the last — usually a client bug).
+        """
+        if not parts:
+            raise ValidationError("parts cannot be empty")
+        # Defensive sort + validation in one pass.
+        normalized: List[Dict[str, Any]] = []
+        for p in parts:
+            n = p.get("part_number")
+            etag = p.get("etag")
+            if not isinstance(n, int) or n < 1 or n > self.MULTIPART_MAX_PART_NUMBER:
+                raise ValidationError(
+                    f"part_number {n} out of range [1, {self.MULTIPART_MAX_PART_NUMBER}]"
+                )
+            if not isinstance(etag, str) or not etag:
+                raise ValidationError(f"part {n} missing etag")
+            # S3 wants etags quoted; the client typically reports them
+            # already-quoted from the response header. Be tolerant.
+            quoted = etag if etag.startswith('"') else f'"{etag}"'
+            normalized.append({"PartNumber": n, "ETag": quoted})
+        normalized.sort(key=lambda p: p["PartNumber"])
+
+        # Tenancy + ownership.
+        echo = await self.get_echo(echo_id, user_id)
+        if not echo:
+            raise NotFoundError(f"Echo {echo_id} not found")
+        if echo.user_id != user_id:
+            raise NotFoundError(f"Echo {echo_id} not found")
+        expected_prefix = f"echoes/{user_id}/{echo_id}_"
+        if not key.startswith(expected_prefix):
+            logger.warning(
+                f"multipart_complete tenancy reject: user={user_id} "
+                f"echo={echo_id} key={key!r}"
+            )
+            raise ValidationError("Object key does not belong to this echo")
+
+        # Assemble the object on S3.
+        try:
+            s3 = await self._get_s3_client()
+            await s3.complete_multipart_upload(
+                Bucket=self.s3_bucket,
+                Key=key,
+                UploadId=upload_id,
+                MultipartUpload={"Parts": normalized},
+            )
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            logger.error(
+                f"S3 complete_multipart_upload failed for {key} " f"(code={code}): {e}"
+            )
+            # NoSuchUpload usually means the abort lifecycle rule already
+            # reaped the upload (client took longer than 7 days), or the
+            # client passed a stale upload_id from a previous attempt.
+            if code in ("NoSuchUpload",):
+                raise NotFoundError("Multipart upload session expired or was aborted")
+            raise InternalServerError(f"Failed to complete multipart upload: {code}")
+
+        # Reuse the single-PUT finalize path for HEAD + atomic commit.
+        # That helper does its own ownership + first-write check; both
+        # already passed above, but defense-in-depth + sharing the same
+        # success path is worth the redundant CPU.
+        return await self.finalize_upload(
+            echo_id=echo_id,
+            user_id=user_id,
+            key=key,
+        )
+
+    async def abort_multipart_upload(
+        self,
+        echo_id: str,
+        user_id: str,
+        upload_id: str,
+        key: str,
+    ) -> None:
+        """Best-effort abort of an in-progress multipart upload.
+
+        Used when the client gives up (user cancels, network is dead).
+        ``NoSuchUpload`` is treated as success — the upload may have been
+        reaped by the bucket lifecycle rule, or this is a duplicate abort
+        from a retry. Either way the desired end state (no upload session
+        consuming bytes) is met.
+        """
+        # Same tenancy/ownership posture as complete.
+        echo = await self.get_echo(echo_id, user_id)
+        if not echo:
+            raise NotFoundError(f"Echo {echo_id} not found")
+        if echo.user_id != user_id:
+            raise NotFoundError(f"Echo {echo_id} not found")
+        expected_prefix = f"echoes/{user_id}/{echo_id}_"
+        if not key.startswith(expected_prefix):
+            raise ValidationError("Object key does not belong to this echo")
+
+        try:
+            s3 = await self._get_s3_client()
+            await s3.abort_multipart_upload(
+                Bucket=self.s3_bucket,
+                Key=key,
+                UploadId=upload_id,
+            )
+            logger.info(
+                f"Aborted multipart upload echo={echo_id} key={key} "
+                f"upload_id={upload_id[:12]}..."
+            )
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code == "NoSuchUpload":
+                logger.info(f"abort_multipart_upload: upload already gone for {key}")
+                return
+            logger.error(f"S3 abort_multipart_upload failed for {key}: {e}")
+            raise InternalServerError(f"Failed to abort upload: {code}")
+
     async def _sign_profile_url(self, url: Optional[str]) -> Optional[str]:
         """Generate presigned GET URL for a profile/avatar image stored in S3.
 

--- a/tests/test_multipart_upload.py
+++ b/tests/test_multipart_upload.py
@@ -1,0 +1,425 @@
+"""Tests for the S3 multipart upload backend.
+
+Covers each of the four service methods:
+  - initiate_multipart_upload: happy path, MIME allowlist, ownership,
+    already-finalized-echo rejection, S3 failure.
+  - generate_multipart_part_urls: batch-size guard, range guard,
+    tenancy reject, parallel fan-out shape.
+  - complete_multipart_upload: parts validation, etag canonicalization,
+    sort-by-part-number, NoSuchUpload mapped to 404, delegation to
+    finalize_upload.
+  - abort_multipart_upload: ownership, NoSuchUpload swallowed.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from src.app.core.exceptions import NotFoundError, ValidationError
+from src.app.models.echo import Echo, EchoStatus, EchoType
+from src.app.services.echo_service import EchoService
+
+
+def _make_echo(echo_id: str = "echo-1", user_id: str = "u-1", media_url=None) -> Echo:
+    return Echo(
+        echo_id=echo_id,
+        user_id=user_id,
+        title="t",
+        status=EchoStatus.DRAFT,
+        echo_type=EchoType.TEXT,
+        media_url=media_url,
+        recipient_id="r-1",
+    )
+
+
+# ----------------------------------------------------------------------
+# initiate_multipart_upload
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_initiate_rejects_unknown_mime():
+    svc = EchoService()
+    echo = _make_echo()
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with pytest.raises(ValidationError, match="Unsupported media type"):
+            await svc.initiate_multipart_upload(
+                echo_id="echo-1",
+                user_id="u-1",
+                file_type="application/x-bad",
+            )
+
+
+@pytest.mark.asyncio
+async def test_initiate_rejects_when_echo_missing():
+    svc = EchoService()
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=None)):
+        with pytest.raises(NotFoundError):
+            await svc.initiate_multipart_upload(
+                echo_id="echo-1",
+                user_id="u-1",
+                file_type="video/mp4",
+            )
+
+
+@pytest.mark.asyncio
+async def test_initiate_rejects_recipient_caller_as_notfound():
+    """Owner-only — recipients see NotFound to avoid info leakage."""
+    svc = EchoService()
+    echo = _make_echo(user_id="owner-u")
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with pytest.raises(NotFoundError):
+            await svc.initiate_multipart_upload(
+                echo_id="echo-1",
+                user_id="recipient-u",
+                file_type="video/mp4",
+            )
+
+
+@pytest.mark.asyncio
+async def test_initiate_rejects_when_media_already_attached():
+    svc = EchoService()
+    echo = _make_echo(media_url="https://b/.../already.mp4")
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with pytest.raises(ValidationError, match="already been finalized"):
+            await svc.initiate_multipart_upload(
+                echo_id="echo-1",
+                user_id="u-1",
+                file_type="video/mp4",
+            )
+
+
+@pytest.mark.asyncio
+async def test_initiate_returns_upload_id_and_key_with_owner_prefix():
+    svc = EchoService()
+    svc.s3_bucket = "mc-bucket"
+    echo = _make_echo()
+    fake_s3 = AsyncMock()
+    fake_s3.create_multipart_upload = AsyncMock(
+        return_value={"UploadId": "UPLOAD-ABC123"}
+    )
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+            result = await svc.initiate_multipart_upload(
+                echo_id="echo-1",
+                user_id="u-1",
+                file_type="video/mp4",
+            )
+
+    assert result["upload_id"] == "UPLOAD-ABC123"
+    assert result["bucket"] == "mc-bucket"
+    assert result["key"].startswith("echoes/u-1/echo-1_")
+    assert result["key"].endswith(".mp4")
+
+    # Verify the create_multipart_upload call carried cache-control + tags + metadata.
+    kwargs = fake_s3.create_multipart_upload.call_args.kwargs
+    assert kwargs["ContentType"] == "video/mp4"
+    assert kwargs["CacheControl"] == "public, max-age=31536000, immutable"
+    assert "user_id=u-1" in kwargs["Tagging"]
+    assert "echo_id=echo-1" in kwargs["Tagging"]
+    assert kwargs["Metadata"]["echo_id"] == "echo-1"
+
+
+@pytest.mark.asyncio
+async def test_initiate_maps_s3_failure_to_internal_error():
+    from src.app.core.exceptions import InternalServerError
+
+    svc = EchoService()
+    echo = _make_echo()
+    fake_s3 = AsyncMock()
+    fake_s3.create_multipart_upload = AsyncMock(
+        side_effect=ClientError(
+            {"Error": {"Code": "InternalError"}}, "CreateMultipartUpload"
+        )
+    )
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+            with pytest.raises(InternalServerError):
+                await svc.initiate_multipart_upload(
+                    echo_id="echo-1",
+                    user_id="u-1",
+                    file_type="video/mp4",
+                )
+
+
+# ----------------------------------------------------------------------
+# generate_multipart_part_urls
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_part_urls_rejects_empty_batch():
+    svc = EchoService()
+    echo = _make_echo()
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with pytest.raises(ValidationError, match="cannot be empty"):
+            await svc.generate_multipart_part_urls(
+                echo_id="echo-1",
+                user_id="u-1",
+                upload_id="UPLOAD",
+                key="echoes/u-1/echo-1_x.mp4",
+                part_numbers=[],
+            )
+
+
+@pytest.mark.asyncio
+async def test_part_urls_rejects_oversize_batch():
+    svc = EchoService()
+    echo = _make_echo()
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with pytest.raises(ValidationError, match="batch exceeds"):
+            await svc.generate_multipart_part_urls(
+                echo_id="echo-1",
+                user_id="u-1",
+                upload_id="UPLOAD",
+                key="echoes/u-1/echo-1_x.mp4",
+                part_numbers=list(range(1, 1002)),  # 1001 parts > 1000 cap
+            )
+
+
+@pytest.mark.parametrize("bad", [0, -1, 10_001, 10_002])
+@pytest.mark.asyncio
+async def test_part_urls_rejects_out_of_range_part_number(bad):
+    svc = EchoService()
+    with pytest.raises(ValidationError, match="out of range"):
+        await svc.generate_multipart_part_urls(
+            echo_id="echo-1",
+            user_id="u-1",
+            upload_id="UPLOAD",
+            key="echoes/u-1/echo-1_x.mp4",
+            part_numbers=[1, 2, bad],
+        )
+
+
+@pytest.mark.asyncio
+async def test_part_urls_rejects_cross_tenant_key():
+    svc = EchoService()
+    echo = _make_echo()
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with pytest.raises(ValidationError, match="does not belong to this echo"):
+            await svc.generate_multipart_part_urls(
+                echo_id="echo-1",
+                user_id="u-1",
+                upload_id="UPLOAD",
+                key="echoes/other-user/echo-1_x.mp4",
+                part_numbers=[1],
+            )
+
+
+@pytest.mark.asyncio
+async def test_part_urls_rejects_recipient_caller_as_notfound():
+    svc = EchoService()
+    echo = _make_echo(user_id="owner-u")
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with pytest.raises(NotFoundError):
+            await svc.generate_multipart_part_urls(
+                echo_id="echo-1",
+                user_id="recipient-u",
+                upload_id="UPLOAD",
+                key="echoes/recipient-u/echo-1_x.mp4",
+                part_numbers=[1],
+            )
+
+
+@pytest.mark.asyncio
+async def test_part_urls_returns_one_url_per_requested_part():
+    svc = EchoService()
+    svc.s3_bucket = "mc-bucket"
+    echo = _make_echo()
+    fake_s3 = AsyncMock()
+    # generate_presigned_url is called once per part with different
+    # PartNumber values; return a distinct URL per call.
+    call_count = {"n": 0}
+
+    async def fake_sign(*_args, **kwargs):
+        call_count["n"] += 1
+        return f"signed-{kwargs['Params']['PartNumber']}"
+
+    fake_s3.generate_presigned_url = fake_sign
+
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+            result = await svc.generate_multipart_part_urls(
+                echo_id="echo-1",
+                user_id="u-1",
+                upload_id="UPLOAD",
+                key="echoes/u-1/echo-1_x.mp4",
+                part_numbers=[1, 2, 3],
+            )
+
+    assert call_count["n"] == 3
+    assert result == [
+        {"part_number": 1, "url": "signed-1"},
+        {"part_number": 2, "url": "signed-2"},
+        {"part_number": 3, "url": "signed-3"},
+    ]
+
+
+# ----------------------------------------------------------------------
+# complete_multipart_upload
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_complete_rejects_empty_parts():
+    svc = EchoService()
+    with pytest.raises(ValidationError, match="parts cannot be empty"):
+        await svc.complete_multipart_upload(
+            echo_id="echo-1",
+            user_id="u-1",
+            upload_id="UPLOAD",
+            key="echoes/u-1/echo-1_x.mp4",
+            parts=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_complete_rejects_part_with_missing_etag():
+    svc = EchoService()
+    with pytest.raises(ValidationError, match="missing etag"):
+        await svc.complete_multipart_upload(
+            echo_id="echo-1",
+            user_id="u-1",
+            upload_id="UPLOAD",
+            key="echoes/u-1/echo-1_x.mp4",
+            parts=[{"part_number": 1, "etag": ""}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_complete_canonicalizes_unquoted_etags_and_sorts_by_part_number():
+    """ETags from S3's wire format are quoted; clients sometimes strip
+    the quotes when reading from response headers. Service must
+    accept both forms and always pass quoted to S3 (which is what
+    CompleteMultipartUpload expects).
+    """
+    svc = EchoService()
+    echo = _make_echo()
+    fake_s3 = AsyncMock()
+    fake_s3.complete_multipart_upload = AsyncMock(return_value={})
+    finalized = _make_echo(media_url="https://b/.../echo-1.mp4")
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+            with patch.object(
+                svc, "finalize_upload", new=AsyncMock(return_value=finalized)
+            ):
+                # Pass parts deliberately out of order, with mixed quoting.
+                await svc.complete_multipart_upload(
+                    echo_id="echo-1",
+                    user_id="u-1",
+                    upload_id="UPLOAD",
+                    key="echoes/u-1/echo-1_x.mp4",
+                    parts=[
+                        {"part_number": 3, "etag": "etag-3"},
+                        {"part_number": 1, "etag": '"etag-1"'},
+                        {"part_number": 2, "etag": "etag-2"},
+                    ],
+                )
+
+    sent = fake_s3.complete_multipart_upload.call_args.kwargs["MultipartUpload"][
+        "Parts"
+    ]
+    # Sorted ascending by PartNumber.
+    assert [p["PartNumber"] for p in sent] == [1, 2, 3]
+    # All quoted.
+    assert sent[0]["ETag"] == '"etag-1"'
+    assert sent[1]["ETag"] == '"etag-2"'
+    assert sent[2]["ETag"] == '"etag-3"'
+
+
+@pytest.mark.asyncio
+async def test_complete_maps_NoSuchUpload_to_notfound():
+    svc = EchoService()
+    echo = _make_echo()
+    fake_s3 = AsyncMock()
+    fake_s3.complete_multipart_upload = AsyncMock(
+        side_effect=ClientError(
+            {"Error": {"Code": "NoSuchUpload"}}, "CompleteMultipartUpload"
+        )
+    )
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+            with pytest.raises(NotFoundError, match="session expired"):
+                await svc.complete_multipart_upload(
+                    echo_id="echo-1",
+                    user_id="u-1",
+                    upload_id="UPLOAD",
+                    key="echoes/u-1/echo-1_x.mp4",
+                    parts=[{"part_number": 1, "etag": "x"}],
+                )
+
+
+@pytest.mark.asyncio
+async def test_complete_rejects_cross_tenant_key():
+    svc = EchoService()
+    echo = _make_echo()
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with pytest.raises(ValidationError, match="does not belong to this echo"):
+            await svc.complete_multipart_upload(
+                echo_id="echo-1",
+                user_id="u-1",
+                upload_id="UPLOAD",
+                key="echoes/other-user/echo-1_x.mp4",
+                parts=[{"part_number": 1, "etag": "x"}],
+            )
+
+
+# ----------------------------------------------------------------------
+# abort_multipart_upload
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_abort_calls_s3_with_upload_id():
+    svc = EchoService()
+    echo = _make_echo()
+    fake_s3 = AsyncMock()
+    fake_s3.abort_multipart_upload = AsyncMock(return_value={})
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+            await svc.abort_multipart_upload(
+                echo_id="echo-1",
+                user_id="u-1",
+                upload_id="UPLOAD",
+                key="echoes/u-1/echo-1_x.mp4",
+            )
+    fake_s3.abort_multipart_upload.assert_awaited_once()
+    kwargs = fake_s3.abort_multipart_upload.call_args.kwargs
+    assert kwargs["UploadId"] == "UPLOAD"
+
+
+@pytest.mark.asyncio
+async def test_abort_swallows_NoSuchUpload():
+    """Already-gone upload is the desired end state."""
+    svc = EchoService()
+    echo = _make_echo()
+    fake_s3 = AsyncMock()
+    fake_s3.abort_multipart_upload = AsyncMock(
+        side_effect=ClientError(
+            {"Error": {"Code": "NoSuchUpload"}}, "AbortMultipartUpload"
+        )
+    )
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+            # Should NOT raise.
+            await svc.abort_multipart_upload(
+                echo_id="echo-1",
+                user_id="u-1",
+                upload_id="UPLOAD",
+                key="echoes/u-1/echo-1_x.mp4",
+            )
+
+
+@pytest.mark.asyncio
+async def test_abort_rejects_recipient_caller():
+    svc = EchoService()
+    echo = _make_echo(user_id="owner-u")
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with pytest.raises(NotFoundError):
+            await svc.abort_multipart_upload(
+                echo_id="echo-1",
+                user_id="recipient-u",
+                upload_id="UPLOAD",
+                key="echoes/recipient-u/echo-1_x.mp4",
+            )


### PR DESCRIPTION
Adds the four-route ceremony around S3 MultipartUpload (initiate / part-urls / complete / abort) so large videos can be uploaded with parallel parts and per-part retry instead of single-PUT all-or-nothing.

- EchoService: initiate / part-urls (batched + parallel-presigned) / complete (etag canonicalization + sort) / abort (NoSuchUpload swallowed). All four enforce owner-only access (recipients see 404) and tenancy on the S3 key prefix.
- complete delegates to finalize_upload for HEAD + atomic DDB commit so finalize semantics are uniform across upload paths.
- Four FastAPI routes; initiate + complete are @idempotent (safe retry over the 429 loop); part-urls is not (would hand back stale signatures); abort is naturally idempotent.
- Bucket LifecycleConfiguration: abort incomplete multipart uploads after 7 days as defense-in-depth against abandoned uploads.
- 23 new tests; full suite 683 passed. mypy clean.

Frontend leg lands as perf/multipart-upload-client (follow-up).