### PR TITLE
fix(multipart): blocker fixes from PR-stack review

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -157,6 +157,17 @@ provider:
             - s3:PutObjectTagging      # for Tagging param in presigned PUT
             - s3:GetObject             # also covers HeadObject in finalize
             - s3:ListBucket
+            # Multipart upload routes — without these the Lambda receives
+            # AccessDenied on every multipart call (initiate / part-urls /
+            # complete / abort). The signer-role needs these even though
+            # the actual UploadPart calls happen from the client against
+            # presigned URLs, because the SigV4 signature is computed
+            # using the role's permissions.
+            - s3:CreateMultipartUpload
+            - s3:UploadPart
+            - s3:CompleteMultipartUpload
+            - s3:AbortMultipartUpload
+            - s3:ListMultipartUploadParts
           Resource:
             - arn:aws:s3:::${self:provider.environment.ECHO_MEDIA_BUCKET}
             - arn:aws:s3:::${self:provider.environment.ECHO_MEDIA_BUCKET}/*

--- a/src/app/services/echo_service.py
+++ b/src/app/services/echo_service.py
@@ -72,6 +72,19 @@ def _looks_like_presigned_url(url: Optional[str]) -> bool:
     return bool(_PRESIGNED_URL_MARKERS.search(url))
 
 
+def _short(s: str, n: int = 12) -> str:
+    """Truncate a long identifier for log lines without assuming length.
+
+    S3 upload IDs are typically ~100+ chars but a test double or future
+    code path could return something shorter; ``s[:12] + "..."`` on a
+    short string is misleading. This helper returns the input unchanged
+    when it's already short enough.
+    """
+    if len(s) <= n:
+        return s
+    return f"{s[:n]}..."
+
+
 # Cache directives we stamp on every PUT presign. Echo media keys embed a
 # timestamp + echo_id so the bytes are effectively immutable; the long
 # max-age + immutable lets browsers and CloudFront (Tier 3) cache without
@@ -1425,6 +1438,8 @@ class EchoService:
         user_id: str,
         key: str,
         content_type: Optional[str] = None,
+        *,
+        skip_media_url_check: bool = False,
     ) -> Echo:
         """Confirm a client-side S3 PUT and atomically commit ``media_url``.
 
@@ -1481,7 +1496,13 @@ class EchoService:
         # second PUT to a different key and overwrite the canonical URL.
         # If we ever support intentional re-upload, that goes through an
         # explicit `replace_media` route with separate auditing.
-        if echo.media_url:
+        #
+        # The multipart-complete path passes skip_media_url_check=True
+        # because S3's CompleteMultipartUpload already succeeded by the
+        # time we reach here. Re-checking would let a concurrent retry
+        # race (or any non-cached @idempotent re-entry) produce a 400
+        # even though the user-facing outcome is success.
+        if echo.media_url and not skip_media_url_check:
             raise ValidationError("Echo media has already been finalized")
 
         # Tenancy check — the key must live directly under this echo's
@@ -1679,8 +1700,8 @@ class EchoService:
 
         upload_id = response["UploadId"]
         logger.info(
-            f"Initiated multipart upload echo={echo_id} key={key} "
-            f"upload_id={upload_id[:12]}..."
+            f"Initiated multipart upload echo={echo_id} key={key!r} "
+            f"upload_id={_short(upload_id)}"
         )
         return {
             "upload_id": upload_id,
@@ -1788,8 +1809,19 @@ class EchoService:
         """
         if not parts:
             raise ValidationError("parts cannot be empty")
-        # Defensive sort + validation in one pass.
+        # Hard cap on the parts array length. Without this a malicious
+        # client could POST 500,000 dicts and exhaust Lambda memory
+        # before reaching any other validation.
+        if len(parts) > self.MULTIPART_MAX_PART_NUMBER:
+            raise ValidationError(
+                f"parts list exceeds {self.MULTIPART_MAX_PART_NUMBER}"
+            )
+        # Defensive sort + dedup + validation in one pass. Duplicates
+        # would silently overwrite each other in S3 — the second ETag
+        # wins, missing parts produce a corrupt assembled object. We
+        # reject loudly instead.
         normalized: List[Dict[str, Any]] = []
+        seen_part_numbers: set[int] = set()
         for p in parts:
             n = p.get("part_number")
             etag = p.get("etag")
@@ -1797,6 +1829,9 @@ class EchoService:
                 raise ValidationError(
                     f"part_number {n} out of range [1, {self.MULTIPART_MAX_PART_NUMBER}]"
                 )
+            if n in seen_part_numbers:
+                raise ValidationError(f"duplicate part_number {n}")
+            seen_part_numbers.add(n)
             if not isinstance(etag, str) or not etag:
                 raise ValidationError(f"part {n} missing etag")
             # S3 wants etags quoted; the client typically reports them
@@ -1841,13 +1876,18 @@ class EchoService:
             raise InternalServerError(f"Failed to complete multipart upload: {code}")
 
         # Reuse the single-PUT finalize path for HEAD + atomic commit.
-        # That helper does its own ownership + first-write check; both
-        # already passed above, but defense-in-depth + sharing the same
-        # success path is worth the redundant CPU.
+        # We've already done the ownership + tenancy checks above, but
+        # finalize_upload re-runs them as defense-in-depth (cheap; one
+        # DDB GetItem). The crucial difference: pass
+        # skip_media_url_check=True because S3's CompleteMultipartUpload
+        # has already succeeded — a strict first-write check here would
+        # 400 on any concurrent retry that races past @idempotent's
+        # cache, even though the user-facing outcome is success.
         return await self.finalize_upload(
             echo_id=echo_id,
             user_id=user_id,
             key=key,
+            skip_media_url_check=True,
         )
 
     async def abort_multipart_upload(
@@ -1883,8 +1923,8 @@ class EchoService:
                 UploadId=upload_id,
             )
             logger.info(
-                f"Aborted multipart upload echo={echo_id} key={key} "
-                f"upload_id={upload_id[:12]}..."
+                f"Aborted multipart upload echo={echo_id} key={key!r} "
+                f"upload_id={_short(upload_id)}"
             )
         except ClientError as e:
             code = e.response.get("Error", {}).get("Code", "")

--- a/tests/test_multipart_upload.py
+++ b/tests/test_multipart_upload.py
@@ -423,3 +423,112 @@ async def test_abort_rejects_recipient_caller():
                 upload_id="UPLOAD",
                 key="echoes/recipient-u/echo-1_x.mp4",
             )
+
+
+# ----------------------------------------------------------------------
+# Review-followup hardening
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_complete_rejects_duplicate_part_numbers():
+    """Two parts with the same part_number would silently let S3 take the
+    last ETag, dropping bytes from the assembled object. Reject loudly.
+    """
+    svc = EchoService()
+    with pytest.raises(ValidationError, match="duplicate part_number"):
+        await svc.complete_multipart_upload(
+            echo_id="echo-1",
+            user_id="u-1",
+            upload_id="UPLOAD",
+            key="echoes/u-1/echo-1_x.mp4",
+            parts=[
+                {"part_number": 1, "etag": "a"},
+                {"part_number": 1, "etag": "b"},  # duplicate
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_complete_rejects_oversize_parts_list():
+    """A malicious client could POST 500k dicts and OOM the Lambda."""
+    svc = EchoService()
+    huge = [
+        {"part_number": i, "etag": f"e-{i}"}
+        for i in range(1, svc.MULTIPART_MAX_PART_NUMBER + 2)
+    ]
+    with pytest.raises(ValidationError, match="exceeds"):
+        await svc.complete_multipart_upload(
+            echo_id="echo-1",
+            user_id="u-1",
+            upload_id="UPLOAD",
+            key="echoes/u-1/echo-1_x.mp4",
+            parts=huge,
+        )
+
+
+@pytest.mark.asyncio
+async def test_complete_passes_skip_media_url_check_to_finalize():
+    """After S3 CompleteMultipartUpload succeeds, finalize_upload must
+    NOT 400 if echo.media_url was somehow already set by a racing
+    concurrent retry. The skip_media_url_check flag closes that TOCTOU
+    window.
+    """
+    svc = EchoService()
+    echo = _make_echo()
+    fake_s3 = AsyncMock()
+    fake_s3.complete_multipart_upload = AsyncMock(return_value={})
+    finalized = _make_echo(media_url="https://b/.../echo-1.mp4")
+
+    captured_kwargs = {}
+
+    async def fake_finalize(**kwargs):
+        captured_kwargs.update(kwargs)
+        return finalized
+
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+            with patch.object(svc, "finalize_upload", side_effect=fake_finalize):
+                await svc.complete_multipart_upload(
+                    echo_id="echo-1",
+                    user_id="u-1",
+                    upload_id="UPLOAD",
+                    key="echoes/u-1/echo-1_x.mp4",
+                    parts=[{"part_number": 1, "etag": "e"}],
+                )
+
+    assert captured_kwargs.get("skip_media_url_check") is True
+
+
+@pytest.mark.asyncio
+async def test_finalize_upload_honors_skip_media_url_check_flag():
+    """If skip_media_url_check=True, an existing echo.media_url no longer
+    raises — the caller (multipart complete) takes responsibility for
+    asserting the write is desired.
+    """
+    svc = EchoService()
+    svc.s3_bucket = "mc-bucket"
+    echo = _make_echo(media_url="https://b/.../already.mp4")
+    fake_s3 = AsyncMock()
+    fake_s3.head_object = AsyncMock(
+        return_value={"ContentLength": 1, "ContentType": "video/mp4", "ETag": '"e"'}
+    )
+    resource = AsyncMock()
+    table = AsyncMock()
+    table.put_item = AsyncMock()
+    resource.Table = AsyncMock(return_value=table)
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+            with patch.object(
+                svc, "_get_dynamodb_resource", new=AsyncMock(return_value=resource)
+            ):
+                # Without the flag this would raise ValidationError.
+                result = await svc.finalize_upload(
+                    echo_id="echo-1",
+                    user_id="u-1",
+                    key="echoes/u-1/echo-1_x.mp4",
+                    skip_media_url_check=True,
+                )
+    assert result.media_url == (
+        "https://mc-bucket.s3.us-east-1.amazonaws.com/echoes/u-1/echo-1_x.mp4"
+    )


### PR DESCRIPTION
Addresses the CRITICAL IAM gap + HIGH correctness items the code-review agents surfaced on perf/multipart-upload after it merged.

CRITICAL
--------
- IAM: add s3:CreateMultipartUpload, s3:UploadPart, s3:CompleteMultipartUpload, s3:AbortMultipartUpload, s3:ListMultipartUploadParts to the EchoVaultMediaBucket grant. Without these the Lambda receives AccessDenied on every multipart call — the merged routes are non-functional in deployment until this lands.

HIGH
----
- Duplicate part_number rejection on complete: a client sending two parts with the same part_number would let S3 silently take the last ETag (dropping the bytes from the other entry). The assembled object would be corrupt without any error path firing. Now we raise ValidationError("duplicate part_number {n}") loudly.
- TOCTOU on finalize_upload reuse: after CompleteMultipartUpload succeeds, finalize_upload would re-check echo.media_url and could raise "already finalized" if a concurrent retry slipped past @idempotent's cache — even though the user-facing outcome is success. New keyword-only `skip_media_url_check` flag lets the multipart-complete path opt out of the first-write check (single-PUT finalize is unchanged).

MEDIUM
------
- Cap parts list length at MULTIPART_MAX_PART_NUMBER (10,000) on complete to prevent OOM via huge client payloads.
- Replace `upload_id[:12]...` with a `_short()` helper that's safe on short strings (test doubles, future code paths).
- Consistent `key={key!r}` in info-level log lines (was: mixed representation, could allow log-injection via embedded newlines).

Tests: 4 new in test_multipart_upload.py (duplicate part_number, oversize parts list, skip_media_url_check propagation, finalize honoring the flag). Full suite: 687 passed (vs 683 = +4). mypy clean.