### PR TITLE
feat(echo): video poster frame — backend route + signing

### DIFF
--- a/src/app/api/echo_routes.py
+++ b/src/app/api/echo_routes.py
@@ -148,6 +148,19 @@ class FinalizeMediaRequest(BaseModel):
     content_type: Optional[str] = None  # caller hint, overridden by S3 HEAD
 
 
+class AttachPosterRequest(BaseModel):
+    """Client tells the backend: "I've uploaded a poster frame for the
+    video at echo {echo_id}; commit it as the thumbnail."
+
+    The poster is a JPEG extracted client-side (via
+    react-native-compressor.createVideoThumbnail) from the same video
+    file the client just successfully uploaded. The backend verifies
+    via HeadObject and writes ``poster_url`` to the echo row.
+    """
+
+    key: str  # S3 object key of the uploaded poster JPEG
+
+
 class MultipartInitiateRequest(BaseModel):
     """Start an S3 multipart upload for a >50 MB file."""
 
@@ -364,6 +377,7 @@ async def finalize_media_upload(
             "status": echo.status.value,
             "content": echo.content,
             "media_url": echo.media_url,
+            "poster_url": echo.poster_url,
             "recipient_id": echo.recipient_id,
             "recipient": echo.recipient,
             "release_date": echo.release_date,
@@ -373,6 +387,51 @@ async def finalize_media_upload(
             "updated_at": echo.updated_at,
         },
         "message": "Echo media finalized",
+    }
+
+
+@router.post(
+    "/echoes/{echo_id}/attach-poster",
+    response_model=Dict[str, Any],
+)
+async def attach_poster_route(
+    echo_id: str,
+    payload: AttachPosterRequest,
+    current_user: Dict[str, Any] = Depends(get_current_user),
+):
+    """Attach a client-extracted poster frame to a video echo.
+
+    The client uses ``react-native-compressor.createVideoThumbnail`` to
+    extract a JPEG at t=1s during the save flow, uploads it via the
+    standard single-PUT presigned URL, then calls this endpoint with
+    the resulting S3 key. The backend HEADs the object to confirm and
+    atomically writes ``poster_url`` to the echo row.
+
+    Not @idempotent — poster attach is naturally idempotent (the
+    second call just overwrites with the same URL).
+    """
+    from ..core.exceptions import NotFoundError, ValidationError
+
+    user_id = current_user["id"]
+
+    try:
+        echo = await echo_service.attach_poster(
+            echo_id=echo_id,
+            user_id=user_id,
+            key=payload.key,
+        )
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return {
+        "success": True,
+        "data": {
+            "echo_id": echo.echo_id,
+            "poster_url": echo.poster_url,
+        },
+        "message": "Echo poster attached",
     }
 
 
@@ -514,6 +573,7 @@ async def complete_multipart_upload(
             "status": echo.status.value,
             "content": echo.content,
             "media_url": echo.media_url,
+            "poster_url": echo.poster_url,
             "recipient_id": echo.recipient_id,
             "recipient": echo.recipient,
             "release_date": echo.release_date,
@@ -602,6 +662,10 @@ async def list_user_echoes(
                 "release_date": e.release_date,
                 "lock_date": e.lock_date,
                 "letter_to_recipient": e.letter_to_recipient,
+                # Pre-signed poster URL for video thumbnails in list
+                # cards. Cheap to include — list-level sign is already
+                # done in get_user_echoes via _sign_poster_urls_for_echoes.
+                "poster_url": e.poster_url,
                 "created_at": e.created_at,
             }
             for e in echoes
@@ -678,6 +742,9 @@ async def list_received_echoes(
                 # otherwise would have surfaced once the bucket public-access
                 # block was tightened in the upload-Tier-A PR.
                 "content": e.content,
+                # Pre-signed poster URL for video thumbnails in inbox
+                # cards. Same parallel-sign helper as the vault list.
+                "poster_url": e.poster_url,
                 "scheduled_at": e.release_date,
                 "created_at": e.created_at,
             }
@@ -711,6 +778,7 @@ async def get_echo(
             "status": echo.status.value,
             "content": echo.content,
             "media_url": echo.media_url,
+            "poster_url": echo.poster_url,
             "recipient_id": echo.recipient_id,
             "recipient": echo.recipient,
             # release_date / lock_date / letter_to_recipient are needed by
@@ -758,6 +826,7 @@ async def update_echo(
                 "status": echo.status.value,
                 "content": echo.content,
                 "media_url": echo.media_url,
+                "poster_url": echo.poster_url,
                 "recipient_id": echo.recipient_id,
                 "recipient": echo.recipient,
                 "release_date": echo.release_date,

--- a/src/app/models/echo.py
+++ b/src/app/models/echo.py
@@ -68,6 +68,11 @@ class Echo:
 
     # Media storage (S3 URL for audio/video, inline for text)
     media_url: Optional[str] = None
+    # Optional video poster frame — JPEG extracted client-side at upload
+    # time. Used as the thumbnail in list views so video cards don't
+    # render as a black rectangle until the player initializes. Set by
+    # POST /echoes/{id}/attach-poster after the video upload succeeds.
+    poster_url: Optional[str] = None
     content: Optional[str] = None  # For text type only
 
     # Status and delivery

--- a/src/app/services/echo_service.py
+++ b/src/app/services/echo_service.py
@@ -619,6 +619,11 @@ class EchoService:
             # this collapses 30 round-trips into one BatchGetItem call.
             await self._enrich_echoes_with_recipients(echoes, user_id)
 
+            # Sign poster URLs in parallel so the vault list can render
+            # video thumbnails directly from the response (without a
+            # follow-up detail-fetch).
+            await self._sign_poster_urls_for_echoes(echoes)
+
             return echoes, next_cursor
 
         except ClientError as e:
@@ -885,6 +890,10 @@ class EchoService:
             # ``limit`` by an order of magnitude, defeating the pagination
             # contract clients depend on.
             echoes = echoes[:page_limit]
+
+            # Sign poster URLs for the page so inbox cards render video
+            # thumbnails directly. Same pattern as get_user_echoes.
+            await self._sign_poster_urls_for_echoes(echoes)
 
             logger.info(f"Inbox: returning {len(echoes)} released echoes")
             return echoes, next_cursor
@@ -1981,6 +1990,40 @@ class EchoService:
         signed = await asyncio.gather(*[self._sign_profile_url(u) for u in url_list])
         return {orig: new for orig, new in zip(url_list, signed) if new is not None}
 
+    async def _sign_poster_urls_for_echoes(self, echoes: List[Echo]) -> None:
+        """Sign every echo's poster_url in parallel (in-place mutation).
+
+        Unlike ``_sign_media_url`` which signs BOTH media_url and
+        poster_url for an echo, this helper signs ONLY poster_url. It's
+        the right tool for list endpoints — the vault list intentionally
+        omits media_url to save presign cost (clients fetch detail-by-id
+        when they need the playable URL), but does want to render the
+        poster thumbnail directly from the list response.
+
+        Uses the same 6h presign TTL as ``_sign_media_url``.
+        """
+        targets = [
+            e for e in echoes if e.poster_url and "amazonaws.com" in e.poster_url
+        ]
+        if not targets:
+            return
+
+        async def sign_one(echo: Echo) -> None:
+            if not echo.poster_url:
+                return
+            try:
+                key = echo.poster_url.split("amazonaws.com/")[-1]
+                s3 = await self._get_s3_client()
+                echo.poster_url = await s3.generate_presigned_url(
+                    "get_object",
+                    Params={"Bucket": self.s3_bucket, "Key": key},
+                    ExpiresIn=21600,
+                )
+            except Exception as e:
+                logger.error(f"Failed to sign poster URL for echo {echo.echo_id}: {e}")
+
+        await asyncio.gather(*[sign_one(e) for e in targets])
+
     async def _sign_media_url(self, echo: Echo) -> Echo:
         """Generate presigned GET URL for secure media playback.
 
@@ -2007,6 +2050,101 @@ class EchoService:
             except Exception as e:
                 logger.error(f"Failed to sign media URL for echo {echo.echo_id}: {e}")
                 # Keep original URL on error
+
+        # Poster URL gets the same treatment when present. We sign both
+        # in one helper because every caller that wants one wants the
+        # other — the poster is functionally part of the same media
+        # asset, just at a smaller frame.
+        if echo.poster_url and "amazonaws.com" in echo.poster_url:
+            try:
+                key = echo.poster_url.split("amazonaws.com/")[-1]
+                s3 = await self._get_s3_client()
+                echo.poster_url = await s3.generate_presigned_url(
+                    "get_object",
+                    Params={"Bucket": self.s3_bucket, "Key": key},
+                    ExpiresIn=21600,
+                )
+            except Exception as e:
+                logger.error(f"Failed to sign poster URL for echo {echo.echo_id}: {e}")
+        return echo
+
+    async def attach_poster(
+        self,
+        echo_id: str,
+        user_id: str,
+        key: str,
+    ) -> Echo:
+        """Verify a poster-image S3 PUT and atomically attach it to the echo.
+
+        Mirrors ``finalize_upload`` but for the optional video-poster
+        slot. Differences:
+
+        - The echo must already have ``media_url`` set (the poster
+          attaches to an existing media; calling this before the video
+          is finalized would orphan the poster).
+        - Re-attaching is allowed — clients that retry after a network
+          blip just overwrite. (The original media has first-write
+          semantics, but the poster is a derived asset; replacing it
+          is a no-op user-visibly.)
+        - Server-side ``HeadObject`` still confirms the object landed
+          and the key prefix still has to belong to this echo, so the
+          poster can't be forged.
+        """
+        echo = await self.get_echo(echo_id, user_id)
+        if not echo:
+            raise NotFoundError(f"Echo {echo_id} not found")
+        # Owner-only (same posture as finalize_upload). Recipients see
+        # NotFound rather than Forbidden — keeps echo existence private.
+        if echo.user_id != user_id:
+            logger.warning(
+                f"attach_poster owner reject: caller={user_id} "
+                f"owner={echo.user_id} echo={echo_id}"
+            )
+            raise NotFoundError(f"Echo {echo_id} not found")
+        if not echo.media_url:
+            raise ValidationError(
+                "Echo has no media to attach a poster to — finalize media first"
+            )
+        expected_prefix = f"echoes/{user_id}/{echo_id}_"
+        if not key.startswith(expected_prefix):
+            logger.warning(
+                f"attach_poster tenancy reject: user={user_id} echo={echo_id} "
+                f"key={key!r}"
+            )
+            raise ValidationError("Object key does not belong to this echo")
+
+        try:
+            s3 = await self._get_s3_client()
+            await s3.head_object(Bucket=self.s3_bucket, Key=key)
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in ("404", "NoSuchKey", "NotFound"):
+                raise NotFoundError(
+                    f"No uploaded poster at s3://{self.s3_bucket}/{key}"
+                )
+            if code in ("403", "AccessDenied", "Forbidden"):
+                logger.error(
+                    f"attach_poster HEAD access denied for {key} "
+                    f"(likely IAM/KMS gap): {e}"
+                )
+                raise InternalServerError("Failed to verify uploaded poster")
+            logger.error(f"attach_poster HEAD failed for {key}: {e}")
+            raise InternalServerError("Failed to verify uploaded poster")
+
+        echo.poster_url = (
+            f"https://{self.s3_bucket}.s3.{self.region}.amazonaws.com/{key}"
+        )
+        echo.updated_at = _current_timestamp()
+
+        try:
+            dynamodb = await self._get_dynamodb_resource()
+            table = await dynamodb.Table(self.echoes_table)
+            await table.put_item(Item=echo.to_dynamodb_item())
+        except ClientError as e:
+            logger.error(f"DynamoDB write failed during attach_poster: {e}")
+            raise InternalServerError(f"Failed to commit poster: {str(e)}")
+
+        logger.info(f"Attached poster to echo {echo_id}: key={key!r}")
         return echo
 
     # ========================================

--- a/tests/test_video_poster.py
+++ b/tests/test_video_poster.py
@@ -1,0 +1,311 @@
+"""Tests for the video-poster attach + signing.
+
+Covers:
+- EchoService.attach_poster: owner-only enforcement, tenancy on key
+  prefix, must-have-media precondition, HeadObject success / missing /
+  access-denied paths, DDB write.
+- _sign_media_url now also signs poster_url when present.
+- _sign_poster_urls_for_echoes parallel signer for list endpoints.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from src.app.core.exceptions import InternalServerError, NotFoundError, ValidationError
+from src.app.models.echo import Echo, EchoStatus, EchoType
+from src.app.services.echo_service import EchoService
+
+
+def _make_echo(
+    echo_id: str = "echo-1",
+    user_id: str = "u-1",
+    media_url: (
+        str | None
+    ) = "https://b.s3.us-east-1.amazonaws.com/echoes/u-1/echo-1_x.mp4",
+    poster_url: str | None = None,
+) -> Echo:
+    return Echo(
+        echo_id=echo_id,
+        user_id=user_id,
+        title="t",
+        status=EchoStatus.RELEASED,
+        echo_type=EchoType.VIDEO,
+        media_url=media_url,
+        poster_url=poster_url,
+        recipient_id="r-1",
+    )
+
+
+def _ddb_resource_mock() -> tuple[AsyncMock, AsyncMock]:
+    table = AsyncMock()
+    table.put_item = AsyncMock()
+    resource = AsyncMock()
+    resource.Table = AsyncMock(return_value=table)
+    return resource, table
+
+
+# ---------------------------------------------------------------------
+# attach_poster — happy path + guards
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_attach_poster_writes_canonical_url_after_HEAD():
+    svc = EchoService()
+    svc.s3_bucket = "mc-bucket"
+    svc.region = "us-east-1"
+
+    echo = _make_echo()
+    fake_s3 = AsyncMock()
+    fake_s3.head_object = AsyncMock(
+        return_value={"ContentLength": 1024, "ContentType": "image/jpeg"}
+    )
+    resource, table = _ddb_resource_mock()
+
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+            with patch.object(
+                svc, "_get_dynamodb_resource", new=AsyncMock(return_value=resource)
+            ):
+                result = await svc.attach_poster(
+                    echo_id="echo-1",
+                    user_id="u-1",
+                    key="echoes/u-1/echo-1_poster.jpg",
+                )
+
+    assert result.poster_url == (
+        "https://mc-bucket.s3.us-east-1.amazonaws.com/echoes/u-1/echo-1_poster.jpg"
+    )
+    table.put_item.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_attach_poster_rejects_recipient_caller_as_notfound():
+    """Recipients get NotFound to avoid info leakage on echo existence."""
+    svc = EchoService()
+    echo = _make_echo(user_id="owner-u")
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with pytest.raises(NotFoundError):
+            await svc.attach_poster(
+                echo_id="echo-1",
+                user_id="recipient-u",
+                key="echoes/recipient-u/echo-1_poster.jpg",
+            )
+
+
+@pytest.mark.asyncio
+async def test_attach_poster_rejects_when_no_media():
+    """Poster attaches to existing media; calling early would orphan
+    the poster on a media-less echo row.
+    """
+    svc = EchoService()
+    echo = _make_echo(media_url=None)
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with pytest.raises(ValidationError, match="no media"):
+            await svc.attach_poster(
+                echo_id="echo-1",
+                user_id="u-1",
+                key="echoes/u-1/echo-1_poster.jpg",
+            )
+
+
+@pytest.mark.asyncio
+async def test_attach_poster_rejects_cross_tenant_key():
+    svc = EchoService()
+    echo = _make_echo()
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with pytest.raises(ValidationError, match="does not belong"):
+            await svc.attach_poster(
+                echo_id="echo-1",
+                user_id="u-1",
+                key="echoes/other-user/echo-1_poster.jpg",
+            )
+
+
+@pytest.mark.asyncio
+async def test_attach_poster_rejects_when_object_missing():
+    svc = EchoService()
+    echo = _make_echo()
+    fake_s3 = AsyncMock()
+    fake_s3.head_object = AsyncMock(
+        side_effect=ClientError({"Error": {"Code": "404"}}, "HeadObject")
+    )
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+            with pytest.raises(NotFoundError, match="No uploaded poster"):
+                await svc.attach_poster(
+                    echo_id="echo-1",
+                    user_id="u-1",
+                    key="echoes/u-1/echo-1_poster.jpg",
+                )
+
+
+@pytest.mark.asyncio
+async def test_attach_poster_maps_403_to_internal_without_leaking():
+    """Access-denied must NOT confirm the object exists."""
+    svc = EchoService()
+    echo = _make_echo()
+    fake_s3 = AsyncMock()
+    fake_s3.head_object = AsyncMock(
+        side_effect=ClientError({"Error": {"Code": "AccessDenied"}}, "HeadObject")
+    )
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+            with pytest.raises(InternalServerError) as exc_info:
+                await svc.attach_poster(
+                    echo_id="echo-1",
+                    user_id="u-1",
+                    key="echoes/u-1/echo-1_poster.jpg",
+                )
+    msg = str(exc_info.value)
+    assert "AccessDenied" not in msg
+    assert "403" not in msg
+
+
+@pytest.mark.asyncio
+async def test_attach_poster_allows_overwrite():
+    """Unlike media_url, poster_url isn't first-write — a retry that
+    overwrites the same URL is a no-op user-visibly.
+    """
+    svc = EchoService()
+    echo = _make_echo(poster_url="https://b.s3.amazonaws.com/old-poster.jpg")
+    fake_s3 = AsyncMock()
+    fake_s3.head_object = AsyncMock(
+        return_value={"ContentLength": 1024, "ContentType": "image/jpeg"}
+    )
+    resource, _table = _ddb_resource_mock()
+    with patch.object(svc, "get_echo", new=AsyncMock(return_value=echo)):
+        with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+            with patch.object(
+                svc, "_get_dynamodb_resource", new=AsyncMock(return_value=resource)
+            ):
+                # Should NOT raise — overwrite allowed.
+                result = await svc.attach_poster(
+                    echo_id="echo-1",
+                    user_id="u-1",
+                    key="echoes/u-1/echo-1_poster.jpg",
+                )
+    assert "echo-1_poster.jpg" in (result.poster_url or "")
+
+
+# ---------------------------------------------------------------------
+# _sign_media_url signs poster_url alongside media_url
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sign_media_url_also_signs_poster_url():
+    svc = EchoService()
+    echo = _make_echo(
+        media_url="https://b.s3.us-east-1.amazonaws.com/echoes/u/e_x.mp4",
+        poster_url="https://b.s3.us-east-1.amazonaws.com/echoes/u/e_x.jpg",
+    )
+    fake_s3 = AsyncMock()
+    # Different signed URLs for each call so we can verify both ran.
+    call_returns = iter(
+        [
+            "https://signed.example/media?sig=1",
+            "https://signed.example/poster?sig=2",
+        ]
+    )
+    fake_s3.generate_presigned_url = AsyncMock(
+        side_effect=lambda *_, **__: next(call_returns)
+    )
+    with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+        signed = await svc._sign_media_url(echo)
+
+    assert signed.media_url == "https://signed.example/media?sig=1"
+    assert signed.poster_url == "https://signed.example/poster?sig=2"
+
+
+@pytest.mark.asyncio
+async def test_sign_media_url_handles_missing_poster_gracefully():
+    """An echo without poster_url should sign media_url only, no error."""
+    svc = EchoService()
+    echo = _make_echo(poster_url=None)
+    fake_s3 = AsyncMock()
+    fake_s3.generate_presigned_url = AsyncMock(return_value="signed-media")
+    with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+        signed = await svc._sign_media_url(echo)
+    assert signed.media_url == "signed-media"
+    assert signed.poster_url is None
+    # Only one call — media, not poster.
+    assert fake_s3.generate_presigned_url.await_count == 1
+
+
+# ---------------------------------------------------------------------
+# _sign_poster_urls_for_echoes — list-endpoint parallel signer
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sign_poster_urls_for_echoes_signs_in_parallel():
+    """Three echoes with posters → exactly 3 sign calls, all in parallel.
+    Echoes without posters are skipped (no sign call).
+    """
+    svc = EchoService()
+    echoes = [
+        _make_echo(
+            echo_id=f"e-{i}",
+            poster_url=f"https://b.s3.us-east-1.amazonaws.com/echoes/u/e-{i}.jpg",
+        )
+        for i in range(3)
+    ] + [_make_echo(echo_id="e-no-poster", poster_url=None)]
+
+    sign_calls: list[str] = []
+    fake_s3 = AsyncMock()
+
+    async def fake_sign(*_, Params, **__):
+        sign_calls.append(Params["Key"])
+        return f"signed::{Params['Key']}"
+
+    fake_s3.generate_presigned_url = fake_sign
+
+    with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+        await svc._sign_poster_urls_for_echoes(echoes)
+
+    # Three signs (e-0, e-1, e-2) — e-no-poster was skipped.
+    assert len(sign_calls) == 3
+    # All three echoes with posters got their URLs signed.
+    for i in range(3):
+        assert echoes[i].poster_url == f"signed::echoes/u/e-{i}.jpg"
+    # No poster on the fourth echo — unchanged.
+    assert echoes[3].poster_url is None
+
+
+@pytest.mark.asyncio
+async def test_sign_poster_urls_for_echoes_handles_empty_list():
+    svc = EchoService()
+    await svc._sign_poster_urls_for_echoes([])  # should not raise
+
+
+@pytest.mark.asyncio
+async def test_sign_poster_urls_for_echoes_keeps_original_on_failure():
+    """A sign failure for one echo doesn't affect the others."""
+    svc = EchoService()
+    echoes = [
+        _make_echo(
+            echo_id=f"e-{i}",
+            poster_url=f"https://b.s3.us-east-1.amazonaws.com/echoes/u/e-{i}.jpg",
+        )
+        for i in range(2)
+    ]
+    originals = [e.poster_url for e in echoes]
+
+    fake_s3 = AsyncMock()
+
+    async def fake_sign(*_, Params, **__):
+        if "e-0" in Params["Key"]:
+            raise ClientError({"Error": {"Code": "X"}}, "GetObject")
+        return f"signed::{Params['Key']}"
+
+    fake_s3.generate_presigned_url = fake_sign
+
+    with patch.object(svc, "_get_s3_client", new=AsyncMock(return_value=fake_s3)):
+        await svc._sign_poster_urls_for_echoes(echoes)
+
+    # e-0 keeps its original URL (sign failed); e-1 is signed.
+    assert echoes[0].poster_url == originals[0]
+    assert echoes[1].poster_url == "signed::echoes/u/e-1.jpg"


### PR DESCRIPTION
POST /api/echoes/{id}/attach-poster commits a client-extracted poster JPEG. The client uses react-native-compressor's createVideoThumbnail to extract a frame at upload time, uploads it via the standard single-PUT path, then calls this route.

- Echo model gains poster_url: Optional[str].
- EchoService.attach_poster: tenancy + ownership checks mirror finalize_upload (recipient → NotFound; cross-tenant key → 400; no media yet → 400). HEAD verifies; 403 → generic InternalServerError. Overwrite is allowed (poster is derived; retry is no-op user-visibly).
- _sign_media_url now signs poster_url alongside media_url for detail.
- _sign_poster_urls_for_echoes: parallel helper for list endpoints — vault + inbox both call it so cards render poster thumbnails without per-row detail-fetch.
- poster_url surfaces in finalize-media + attach-poster + get_echo + update_echo + vault list + inbox list responses.

Why client-side (not Lambda + ffmpeg)
-------------------------------------
- Faster: poster appears with the echo, not 30-60 s after via async pipeline.
- Zero new infra: no ffmpeg layer, no MediaConvert role, no S3 event.
- Cheaper: no per-frame Lambda or MediaConvert minutes. Trade-off: poster generated on-device using the same codec stack as the source. Acceptable — RNC uses AVAssetImageGenerator (iOS) / MediaMetadataRetriever (Android), both proven.

HLS adaptive bitrate is deliberately deferred; the user complaint that seeded the perf workstream (slow uploads) is fully addressed by 720p compression.

Tests: 12 new (attach happy-path, recipient reject, no-media, cross-tenant, missing object, 403 leak guard, overwrite allowed, _sign_media_url also signs poster, _sign_poster_urls_for_echoes parallel + isolation). Full suite: 715 passed (+12). mypy clean.

Frontend leg: feat/video-poster-frame-client.