### PR TITLE
chore(api): apply @idempotent to release_echo + create_recipient + cr…

### DIFF
--- a/src/app/api/echo_routes.py
+++ b/src/app/api/echo_routes.py
@@ -861,8 +861,10 @@ async def delete_echo(
 
 
 @router.patch("/echoes/{echo_id}/release", response_model=Dict[str, Any])
+@idempotent(route_id="release_echo")
 async def release_echo(
     echo_id: str,
+    request: Request,
     current_user: Dict[str, Any] = Depends(get_current_user),
 ):
     """
@@ -875,6 +877,12 @@ async def release_echo(
 
     On success the echo status transitions to RELEASED and the recipient
     receives a notification email.
+
+    Idempotent: the recipient-notification email is a user-visible
+    side effect, so a 429-driven retry hitting this twice without
+    dedup would surface as a duplicate email. The @idempotent wrapper
+    caches the original response under the client's Idempotency-Key
+    for 24 h and returns it verbatim on retries.
     """
     from ..core.exceptions import NotFoundError, ValidationError
 
@@ -990,15 +998,23 @@ async def list_recipients(
 
 
 @router.post("/recipients", response_model=Dict[str, Any], status_code=201)
+@idempotent(route_id="create_recipient")
 async def create_recipient(
-    request: CreateRecipientRequest,
+    payload: CreateRecipientRequest,
+    request: Request,
     current_user: Dict[str, Any] = Depends(get_current_user),
 ):
-    """Add a new recipient. Triggers invitation email."""
+    """Add a new recipient. Triggers invitation email.
+
+    Idempotent: the invitation email is a user-visible side effect.
+    A 429-driven retry without dedup would produce a duplicate
+    invitation. @idempotent caches the response so retries within
+    the 24h window are no-ops on the server side.
+    """
     user_id = current_user["id"]
     user_name = current_user.get("name", current_user.get("email", "Someone"))
 
-    recipient = await echo_service.create_recipient(user_id, request.model_dump())
+    recipient = await echo_service.create_recipient(user_id, payload.model_dump())
 
     # Send invitation email (fire-and-forget, don't block on failure)
     try:
@@ -1090,15 +1106,21 @@ async def list_guardians(
 
 
 @router.post("/guardians", response_model=Dict[str, Any], status_code=201)
+@idempotent(route_id="create_guardian")
 async def create_guardian(
-    request: CreateGuardianRequest,
+    payload: CreateGuardianRequest,
+    request: Request,
     current_user: Dict[str, Any] = Depends(get_current_user),
 ):
-    """Add a new guardian. Triggers invitation email."""
+    """Add a new guardian. Triggers invitation email.
+
+    Idempotent for the same reason as create_recipient — the
+    guardian-invite email shouldn't double-send on retry.
+    """
     user_id = current_user["id"]
     user_name = current_user.get("name", current_user.get("email", "Someone"))
 
-    guardian = await echo_service.create_guardian(user_id, request.model_dump())
+    guardian = await echo_service.create_guardian(user_id, payload.model_dump())
 
     # Send invitation email (fire-and-forget, don't block on failure)
     try:


### PR DESCRIPTION
…eate_guardian

Closes a follow-up flagged in the PR-stack review: idempotency keys were missing on the three write endpoints whose side effects are user-visible (outbound email).

- PATCH /echoes/{id}/release   — recipient gets the echo-released
  notification email. A 429-driven retry without dedup produces a
  duplicate email.
- POST /recipients              — recipient gets an invitation email.
  Same duplicate-email risk.
- POST /guardians               — guardian gets an invitation email.
  Same.

All three now wrap with @idempotent(route_id=...). The Pydantic body param was renamed from 'request' → 'payload' on create_recipient and create_guardian to free 'request' for the FastAPI Request injection the decorator reads. release_echo had no body so just adds the new parameter.

The decorator's behavior is exhaustively tested in tests/ test_idempotency.py (15 tests covering hit / miss / oversize key / cache-failure / non-dict response / etc). No new tests needed at the route level beyond confirming nothing broke.

Full backend suite: 715 passed (unchanged). mypy clean.