### PR TITLE
fix(sns): wire iOS + Android Platform Application ARNs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,8 @@ jobs:
         OPENAI_API_KEY: ${{ secrets.STAGING_OPENAI_API_KEY }}
         SES_SENDER_EMAIL: ${{ secrets.STAGING_SES_SENDER_EMAIL }}
         SNS_TOPIC_ARN: ${{ secrets.STAGING_SNS_TOPIC_ARN }}
+        SNS_IOS_APP_ARN: ${{ secrets.STAGING_SNS_IOS_APP_ARN }}
+        SNS_ANDROID_APP_ARN: ${{ secrets.STAGING_SNS_ANDROID_APP_ARN }}
         APP_URL: ${{ secrets.STAGING_APP_URL }}
 
   deploy-production:
@@ -262,6 +264,8 @@ jobs:
         OPENAI_API_KEY: ${{ secrets.PROD_OPENAI_API_KEY }}
         SES_SENDER_EMAIL: ${{ secrets.PROD_SES_SENDER_EMAIL }}
         SNS_TOPIC_ARN: ${{ secrets.PROD_SNS_TOPIC_ARN }}
+        SNS_IOS_APP_ARN: ${{ secrets.PROD_SNS_IOS_APP_ARN }}
+        SNS_ANDROID_APP_ARN: ${{ secrets.PROD_SNS_ANDROID_APP_ARN }}
         APP_URL: ${{ secrets.PROD_APP_URL }}
 
   notify:

--- a/serverless.yml
+++ b/serverless.yml
@@ -20,6 +20,15 @@ provider:
     OPENAI_API_KEY: ${env:OPENAI_API_KEY, ''}
     # SNS/SES Notifications
     SNS_TOPIC_ARN: ${env:SNS_TOPIC_ARN, ''}
+    # Platform Application ARNs for direct device push (APNs / FCM).
+    # The SNS service falls back to logging an error and returning a
+    # configuration HTTP 500 when these are unset, which is the symptom
+    # iOS clients see as "platform ios is not configured" on
+    # /api/register-device. Create the platform applications in the
+    # AWS Console (SNS → Mobile → Push notifications) and set the ARNs
+    # via the corresponding GitHub Secrets (see ci.yml).
+    SNS_IOS_APP_ARN: ${env:SNS_IOS_APP_ARN, ''}
+    SNS_ANDROID_APP_ARN: ${env:SNS_ANDROID_APP_ARN, ''}
     SES_SENDER_EMAIL: ${env:SES_SENDER_EMAIL, 'noreply@mirrorcollective.com'}
     APP_NAME: "Mirror Collective"
     APP_URL: ${env:APP_URL, 'https://mirrorcollective.com'}


### PR DESCRIPTION
iOS clients hit a 500 on POST /api/register-device with the log line 'Push notification platform ios is not configured'. The SNS service already reads SNS_IOS_APP_ARN / SNS_ANDROID_APP_ARN via os.getenv(), but neither variable was wired through serverless.yml or ci.yml, so the Lambda never saw them.

  • serverless.yml: declare SNS_IOS_APP_ARN + SNS_ANDROID_APP_ARN
    under provider.environment, defaulting to empty string so an
    unset secret degrades gracefully (logged error + 500 on the one
    register-device endpoint) instead of failing the whole stack.
  • ci.yml: thread the values through both deploy blocks
    (staging-v2 + production-v2) from new GitHub Secrets:
      STAGING_SNS_IOS_APP_ARN     PROD_SNS_IOS_APP_ARN
      STAGING_SNS_ANDROID_APP_ARN PROD_SNS_ANDROID_APP_ARN

Operator action required to fully resolve:
  1. AWS Console → SNS → Mobile → Push notifications → create APNS_SANDBOX (staging) + APNS (production) platform apps using an Apple p8 auth key.
  2. Same for Android via FCM credentials.
  3. Paste each ARN into the four matching GitHub Secrets above.
  4. Redeploy. /api/register-device returns 200 thereafter.