### PR TITLE
fix(iam): grant dynamodb:BatchGetItem to Lambda role

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -69,6 +69,12 @@ provider:
             - dynamodb:Query
             - dynamodb:Scan
             - dynamodb:GetItem
+            # BatchGetItem is used by EchoService to collapse per-row
+            # recipient enrichment lookups into a single round-trip
+            # (see services/echo_service.py:_batch_get_recipients).
+            # Without this grant the lambda hits AccessDenied on every
+            # GET /api/echoes and returns 500.
+            - dynamodb:BatchGetItem
             - dynamodb:PutItem
             - dynamodb:UpdateItem
             - dynamodb:DeleteItem


### PR DESCRIPTION
GET /api/echoes returns 500 on production with:
  User ... is not authorized to perform: dynamodb:BatchGetItem
  on resource: ...mirror-collective-python-api-recipients-production-v2

EchoService batches per-row recipient lookups via batch_get_item to collapse N round-trips into one (see _batch_get_recipients, echo_service.py:700). The action wasn't in the IAM allow-list, so the call AccessDenies and the endpoint returns 500.

One-line fix: add dynamodb:BatchGetItem to the existing allow block that already grants the per-table Resource ARNs for echoes / recipients / guardians etc. No new resources needed.