### PR TITLE
fix(quiz): align Q5 Weaver option with V1 onboarding spec

### DIFF
--- a/src/app/data/questions.json
+++ b/src/app/data/questions.json
@@ -161,7 +161,7 @@
           "archetype": "Flamebearer"
         },
         {
-          "text": "I'm here to weave something meaningful.",
+          "text": "I'm here to build something meaningful.",
           "archetype": "Weaver"
         }
       ],


### PR DESCRIPTION
The V1 Archetype Onboarding Quiz spec reads:
  "I'm here to build something meaningful." → Weaver
Backend currently has:
  "I'm here to weave something meaningful." → Weaver

Same archetype mapping (Weaver) and same scoring metadata, so this is a copy-only change. After merge, run scripts/populate_quiz_questions.py against the deployed DynamoDB to push the updated text — the script does put_item upserts so the existing Q5 row is overwritten safely.