### PR TITLE
fix(echo): presigned PUT 403 — sign client's exact Content-Type

### DIFF
--- a/src/app/services/echo_service.py
+++ b/src/app/services/echo_service.py
@@ -1390,7 +1390,12 @@ class EchoService:
         Raises:
             ValidationError: ``file_type`` is not on the upload allowlist.
         """
-        # Normalize client-reported aliases (image/jpg -> image/jpeg, etc.).
+        # The presigned PUT signs Content-Type, so the value we sign MUST equal
+        # the Content-Type header the client sends — otherwise S3 rejects the
+        # PUT with 403 SignatureDoesNotMatch. The client sends back the exact
+        # string it passed here, so sign THAT (requested_type). We normalize a
+        # separate copy only for the allowlist check + extension mapping.
+        requested_type = file_type
         file_type = _normalize_mime(file_type)
         if file_type not in ALLOWED_UPLOAD_MIME_TYPES:
             raise ValidationError(
@@ -1451,7 +1456,9 @@ class EchoService:
             put_params: Dict[str, Any] = {
                 "Bucket": self.s3_bucket,
                 "Key": key,
-                "ContentType": file_type,
+                # Sign the client's exact Content-Type (not the normalized one)
+                # so the PUT header matches the signature — see requested_type.
+                "ContentType": requested_type,
                 "CacheControl": _PUT_CACHE_CONTROL,
                 "Tagging": tagging,
                 "Metadata": metadata,

--- a/tests/test_echo_attachments.py
+++ b/tests/test_echo_attachments.py
@@ -286,6 +286,21 @@ def test_mime_alias_normalization():
 
 
 @pytest.mark.asyncio
+async def test_upload_url_signs_original_content_type():
+    # image/jpg is normalized for the allowlist + extension, but the presigned
+    # PUT must sign the client's EXACT Content-Type so the PUT header matches
+    # (else S3 returns 403 SignatureDoesNotMatch).
+    service, _, s3 = _wire_service(_echo_row())
+    s3.generate_presigned_url.return_value = "https://presigned"
+    out = await service.generate_upload_url(
+        user_id="user-1", file_type="image/jpg", echo_id="echo-1"
+    )
+    params = s3.generate_presigned_url.call_args.kwargs["Params"]
+    assert params["ContentType"] == "image/jpg"  # verbatim, NOT image/jpeg
+    assert out["key"].endswith(".jpg")  # extension from the normalized type
+
+
+@pytest.mark.asyncio
 async def test_add_attachment_pdf_classified_as_file():
     service, _, _ = _wire_service(
         _echo_row(),


### PR DESCRIPTION
The presigned PUT signs Content-Type, so the signed value must equal the client's PUT header. The MIME-alias fix normalized file_type in place and signed the normalized value (image/jpeg) while the client still PUTs the original (image/jpg) → S3 403 SignatureDoesNotMatch.

Sign the client's exact requested Content-Type; normalize a separate copy only for the allowlist check + extension mapping. Multipart is unaffected (upload_part presign doesn't sign Content-Type).

Test: upload-url signs the verbatim type, key uses the normalized extension.