### PR TITLE
chore(email): set SES sender to app@themirrorcollective.com

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -20,7 +20,7 @@ provider:
     OPENAI_API_KEY: ${env:OPENAI_API_KEY, ''}
     # SNS/SES Notifications
     SNS_TOPIC_ARN: ${env:SNS_TOPIC_ARN, ''}
-    SES_SENDER_EMAIL: ${env:SES_SENDER_EMAIL, 'noreply@mirrorcollective.com'}
+    SES_SENDER_EMAIL: ${env:SES_SENDER_EMAIL, 'app@themirrorcollective.com'}
     APP_NAME: "Mirror Collective"
     APP_URL: ${env:APP_URL, 'https://mirrorcollective.com'}
     # Public tokenized echo viewer (email-recipient attachment playback).

--- a/src/app/services/email_service.py
+++ b/src/app/services/email_service.py
@@ -118,9 +118,7 @@ class EmailService:
     def __init__(self):
         """Initialize Email service"""
         self.region = os.getenv("AWS_REGION", "us-east-1")
-        self.sender_email = os.getenv(
-            "SES_SENDER_EMAIL", "noreply@mirrorcollective.com"
-        )
+        self.sender_email = os.getenv("SES_SENDER_EMAIL", "app@themirrorcollective.com")
         self.app_name = os.getenv("APP_NAME", "Mirror Collective")
         self.app_url = os.getenv("APP_URL", "https://mirrorcollective.com")
         self.app_store_url = os.getenv(


### PR DESCRIPTION
Update SES_SENDER_EMAIL default (serverless env + code fallback) to the verified sender. Override per-stage via the SES_SENDER_EMAIL env var if needed.