### PR TITLE
fix(ci): package email templates + sync brand assets on deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,13 @@ jobs:
         cp -r src/ build/
         cp requirements.txt build/
         cp serverless.yml build/
+        # Compiled echo-share email templates, rendered at runtime by
+        # email_service.py (serverless.yml packages `emails/dist/**`). The
+        # deploy runs from build/, so they MUST be copied here too — without
+        # this the Lambda's /var/task/emails/dist is empty and every echo
+        # email falls back to plain HTML.
+        mkdir -p build/emails
+        cp -r emails/dist build/emails/dist
         # Create package.json for serverless plugins
         echo '{"dependencies": {"serverless-python-requirements": "5.4.0"}}' > build/package.json
 
@@ -199,6 +206,15 @@ jobs:
         SNS_TOPIC_ARN: ${{ secrets.STAGING_SNS_TOPIC_ARN }}
         APP_URL: ${{ secrets.STAGING_APP_URL }}
 
+    # Upload the rich-email brand images to the public bucket the deploy just
+    # created (mirror-collective-email-assets-<stage>). Runs from the repo
+    # checkout (not build/), which has emails/email-assets/.
+    - name: Sync email brand assets
+      run: |
+        aws s3 sync emails/email-assets \
+          s3://mirror-collective-email-assets-staging/ \
+          --cache-control "public, max-age=31536000"
+
   deploy-production:
     runs-on: ubuntu-latest
     needs: build
@@ -263,6 +279,15 @@ jobs:
         SES_SENDER_EMAIL: ${{ secrets.PROD_SES_SENDER_EMAIL }}
         SNS_TOPIC_ARN: ${{ secrets.PROD_SNS_TOPIC_ARN }}
         APP_URL: ${{ secrets.PROD_APP_URL }}
+
+    # Upload brand images to the public bucket created by the deploy. Prod
+    # deploys to stage "production-v2", so the bucket is
+    # mirror-collective-email-assets-production-v2.
+    - name: Sync email brand assets
+      run: |
+        aws s3 sync emails/email-assets \
+          s3://mirror-collective-email-assets-production-v2/ \
+          --cache-control "public, max-age=31536000"
 
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Root cause of recipient emails falling back to plain HTML: the build job's "Create deployment package" step copied only src/, requirements.txt and serverless.yml into build/ — never emails/. serverless deploy then ran from build/, so the emails/dist/** pattern matched nothing and the Lambda shipped with an empty /var/task/emails/dist (CloudWatch: "'echo-written.html' not found in search path: '/var/task/emails/dist'").

- Copy emails/dist into build/emails/dist before deploy.
- After each deploy, sync emails/email-assets to the public mirror-collective-email-assets-<stage> bucket so the inline images resolve (staging, production-v2).