### PR TITLE
fix(share-viewer): scoped CSP so images + inline video/audio load

### DIFF
--- a/src/app/api/share_routes.py
+++ b/src/app/api/share_routes.py
@@ -43,6 +43,26 @@ _GET_APP_URL = os.getenv("APP_STORE_URL", _APP_URL)
 # expired/dead link. Defends against a misconfigured CDN/browser cache.
 _NO_STORE = {"Cache-Control": "no-store"}
 
+# Viewer-scoped Content-Security-Policy. The global security-headers middleware
+# (app/handler.py) sets a strict `default-src 'self'` CSP via `setdefault`,
+# which would block EVERYTHING this page needs — brand images + inline
+# <video>/<audio> served from S3, and the Google web fonts — so the browser
+# refuses to load the media (it 206s fine over the wire; CSP blocks it client
+# side). Because the middleware uses setdefault, setting our own CSP here wins.
+# Scope: images + media from any AWS S3 host (asset bucket + vault/accelerate
+# media), styles/fonts from Google, and no scripts at all.
+_VIEWER_CSP = (
+    "default-src 'self'; "
+    "img-src 'self' https://*.amazonaws.com data:; "
+    "media-src 'self' https://*.amazonaws.com; "
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+    "font-src 'self' https://fonts.gstatic.com; "
+    "script-src 'none'; "
+    "base-uri 'none'; "
+    "form-action 'none'"
+)
+_PAGE_HEADERS = {"Cache-Control": "no-store", "Content-Security-Policy": _VIEWER_CSP}
+
 _DAY_SUFFIXES = {1: "st", 2: "nd", 3: "rd"}
 
 
@@ -213,7 +233,7 @@ def _page(title: str, body: str, status: int = 200) -> HTMLResponse:
 <a class="cta" href="{html.escape(_GET_APP_URL)}">GET THE APP</a>
 <div class="footer"><img src="{_ASSET_BASE}/icon-lock.png" alt="" />Shared privately through Echo Vault</div>
 </div></body></html>"""
-    return HTMLResponse(doc, status_code=status, headers=_NO_STORE)
+    return HTMLResponse(doc, status_code=status, headers=_PAGE_HEADERS)
 
 
 def _error_page(message: str, status: int) -> HTMLResponse:

--- a/tests/test_echo_share_viewer.py
+++ b/tests/test_echo_share_viewer.py
@@ -257,6 +257,39 @@ async def test_viewer_matches_branding_and_plays_every_media_type_in_page():
     assert "divider-star.png" in body
     assert "icon-lock.png" in body
     assert "email-bg-starfield.png" in body
+    # The viewer MUST ship a CSP that permits its own resources. The global
+    # security-headers middleware sets `default-src 'self'` via setdefault,
+    # which would block the S3 images + <video>/<audio> media and the Google
+    # fonts (the live "media won't play / logo broken" bug). The page sets its
+    # own CSP so setdefault leaves it intact.
+    csp = resp.headers["content-security-policy"]
+    assert "img-src" in csp and "https://*.amazonaws.com" in csp
+    assert "media-src 'self' https://*.amazonaws.com" in csp
+    assert "fonts.googleapis.com" in csp and "fonts.gstatic.com" in csp
+
+
+@pytest.mark.asyncio
+async def test_viewer_csp_overrides_strict_global_default():
+    """Sanity: the viewer response carries a permissive, media-friendly CSP
+    (not the global `default-src 'self'`) so the browser loads S3 media."""
+    echo = Echo(
+        echo_id="e1",
+        recipient_id="r1",
+        status=EchoStatus.RELEASED,
+        content="hi",
+    )
+    tok = create_share_token("e1", "r1")
+    with patch.object(
+        share_routes.echo_service, "get_shared_echo", AsyncMock(return_value=echo)
+    ):
+        resp = await share_routes.shared_echo_viewer("e1", t=tok)
+    csp = resp.headers["content-security-policy"]
+    # Must NOT be the bare strict policy that blocks media/images.
+    assert csp != "default-src 'self'"
+    assert "media-src" in csp
+    # Error pages carry the CSP too (they also load fonts + logo).
+    err = share_routes._error_page("nope", 404)
+    assert "media-src" in err.headers["content-security-policy"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The global security-headers middleware sets `Content-Security-Policy: default-src 'self'` on every response (via setdefault). On the share viewer that silently BLOCKED, client-side, every external resource: the brand images, the Google web fonts, and — the reported bug — the inline <video>/<audio> served from S3. The media itself was fine (S3 returned 206 with the right Content-Type); the browser just refused to load it. curl didn't surface this because curl ignores CSP.

Set a viewer-scoped CSP on the page (and error) responses that permits img/media from S3 (*.amazonaws.com), styles/fonts from Google, and no scripts. setdefault in the middleware leaves our header intact. Verified in a browser: logo, starfield, inline image, and the video + audio players all load and play; downloads unaffected.