### PR TITLE
fix: align registration validation with client and log failing field

### DIFF
--- a/src/app/api/models.py
+++ b/src/app/api/models.py
@@ -1,13 +1,25 @@
 import re
+import string
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, EmailStr, Field, field_validator
+
+# Characters accepted as a "special character" in passwords. This deliberately
+# mirrors the set the mobile SignUp form accepts (any common ASCII symbol) so the
+# client and server agree — a narrower server set silently rejected passwords the
+# app had already accepted, surfacing as "Registration Failed" (HTTP 422).
+PASSWORD_SPECIAL_CHARS = set(string.punctuation)
+
+# Characters allowed in a name in addition to letters: spaces, period (initials),
+# apostrophe and hyphen. Letters are matched via ``str.isalpha()`` which is
+# Unicode-aware, so accented and international names (e.g. "José García") are valid.
+NAME_EXTRA_CHARS = set(" .'-")
 
 
 class UserRegistrationRequest(BaseModel):
     email: EmailStr
     password: str = Field(min_length=8)
-    fullName: str = Field(min_length=2, max_length=100, pattern=r"^[a-zA-Z\s\'-]+$")
+    fullName: str = Field(min_length=2, max_length=100)
     phoneNumber: Optional[str] = None
     termsAcceptedAt: Optional[str] = None
     anonymousId: Optional[str] = None  # For linking anonymous quiz data
@@ -23,8 +35,22 @@ class UserRegistrationRequest(BaseModel):
             raise ValueError("Password must contain at least one uppercase letter")
         if not re.search(r"\d", v):
             raise ValueError("Password must contain at least one digit")
-        if not re.search(r"[@$!%*?&]", v):
+        if not any(c in PASSWORD_SPECIAL_CHARS for c in v):
             raise ValueError("Password must contain at least one special character")
+        return v
+
+    @field_validator("fullName")
+    @classmethod
+    def validate_full_name(cls, v):
+        # Allow Unicode letters plus spaces, periods, apostrophes and hyphens.
+        # Reject digits and other symbols.
+        if not all(c.isalpha() or c in NAME_EXTRA_CHARS for c in v):
+            raise ValueError(
+                "Full name may only contain letters, spaces, periods, "
+                "apostrophes and hyphens"
+            )
+        if not any(c.isalpha() for c in v):
+            raise ValueError("Full name must contain at least one letter")
         return v
 
 

--- a/src/app/core/error_handlers.py
+++ b/src/app/core/error_handlers.py
@@ -172,8 +172,14 @@ async def validation_exception_handler(request: Request, exc: Exception) -> Resp
         )
         validation_errors.append({"field": field_path, "message": error["msg"]})
 
+    # Include the failing field(s) in the message itself so they are visible in
+    # log aggregators (e.g. CloudWatch) that don't render the structured `extra`.
+    error_summary = "; ".join(
+        f"{e['field']}: {e['message']}" for e in validation_errors
+    )
     logger.warning(
-        f"Validation Error: {len(validation_errors)} errors",
+        f"Validation Error on {request.method} {request.url.path}: "
+        f"{len(validation_errors)} error(s) - {error_summary}",
         extra={
             "request_id": request_id,
             "path": request.url.path,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -67,6 +67,70 @@ def test_user_registration_request_invalid_name():
     assert "fullName" in str(exc_info.value)
 
 
+def test_password_accepts_common_special_chars():
+    """Fix #1: backend must accept the same special characters the app allows.
+
+    The mobile SignUp form accepts any common ASCII symbol, but the API used to
+    allow only ``@$!%*?&`` — so passwords like ``Welcome#2024`` passed the form
+    and were rejected by the server (HTTP 422 -> "Registration Failed").
+    """
+    accepted = [
+        "Welcome#2024",  # hash
+        "MyPass_1234",  # underscore
+        "Hello.World1",  # period
+        "Strong-Pass1",  # hyphen
+        "Caret^Pass1",  # caret
+        "Tilde~Pass1",  # tilde
+        "Paren(Pass1)",  # parentheses
+    ]
+    for password in accepted:
+        request = UserRegistrationRequest(
+            email="test@example.com", password=password, fullName="Test User"
+        )
+        assert request.password == password
+
+
+def test_password_still_requires_a_special_char():
+    """A purely alphanumeric password is still rejected."""
+    with pytest.raises(ValidationError) as exc_info:
+        UserRegistrationRequest(
+            email="test@example.com", password="NoSpecial123", fullName="Test User"
+        )
+    assert "special character" in str(exc_info.value)
+
+
+def test_fullname_accepts_international_and_punctuation():
+    """Fix #2: accented / international names and initials must be accepted.
+
+    The old pattern ``^[a-zA-Z\\s'-]+$`` rejected accents and periods, blocking
+    valid users such as ``José García`` and ``John A. Smith``.
+    """
+    accepted = [
+        "José García",  # accents
+        "Müller",  # umlaut
+        "Renée Dubois",  # accent
+        "Anne-Marie O'Brien",  # hyphen + apostrophe
+        "John A. Smith",  # middle initial with period
+        "Sven Åkesson",  # ring
+    ]
+    for name in accepted:
+        request = UserRegistrationRequest(
+            email="test@example.com", password="ValidPass123!", fullName=name
+        )
+        assert request.fullName == name
+
+
+def test_fullname_rejects_digits_and_symbols():
+    """Names containing digits or non-name symbols are still rejected."""
+    rejected = ["John123", "Test@User", "name!!", "<script>"]
+    for name in rejected:
+        with pytest.raises(ValidationError) as exc_info:
+            UserRegistrationRequest(
+                email="test@example.com", password="ValidPass123!", fullName=name
+            )
+        assert "fullName" in str(exc_info.value)
+
+
 def test_login_request_valid():
     """Test valid login request"""
     data = {"email": "test@example.com", "password": "password123"}

--- a/tests/test_validation_error_logging.py
+++ b/tests/test_validation_error_logging.py
@@ -1,0 +1,64 @@
+"""Fix #3: the validation error handler must log *which* field failed.
+
+Previously the handler logged only ``Validation Error: N errors`` (a bare count),
+so CloudWatch could not reveal which field caused a registration 422. These tests
+assert the failing field name and message are included in the emitted log line.
+"""
+
+import asyncio
+import logging
+
+from fastapi.exceptions import RequestValidationError
+from starlette.requests import Request
+
+from src.app.api.models import UserRegistrationRequest
+from src.app.core.error_handlers import validation_exception_handler
+
+
+def _make_request(path: str = "/api/auth/register") -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "headers": [],
+        "query_string": b"",
+    }
+    return Request(scope)
+
+
+def _validation_error_for_bad_registration() -> RequestValidationError:
+    """Build a real RequestValidationError from a failing registration payload."""
+    from pydantic import ValidationError
+
+    try:
+        UserRegistrationRequest(
+            email="test@example.com",
+            password="NoSpecial123",  # missing special char
+            fullName="Valid Name",
+        )
+    except ValidationError as exc:
+        return RequestValidationError(exc.errors())
+    raise AssertionError("payload was expected to fail validation")
+
+
+def test_handler_logs_failing_field_name(caplog):
+    request = _make_request()
+    exc = _validation_error_for_bad_registration()
+
+    with caplog.at_level(logging.WARNING):
+        asyncio.run(validation_exception_handler(request, exc))
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "expected a warning log for the validation error"
+    log_text = " ".join(r.getMessage() for r in warnings)
+    # The field that failed must be identifiable from the log message itself.
+    assert "password" in log_text
+    assert "/api/auth/register" in log_text
+
+
+def test_handler_response_still_returns_validation_errors():
+    request = _make_request()
+    exc = _validation_error_for_bad_registration()
+
+    response = asyncio.run(validation_exception_handler(request, exc))
+    assert response.status_code == 422


### PR DESCRIPTION
Several users hit "Registration Failed" — CloudWatch showed 11 of 16 POST /api/auth/register attempts over 5 days returning HTTP 422, rejected at request validation in 3-4ms (before Cognito). The API was stricter than the mobile SignUp form, so inputs the app accepted were rejected server-side.

- password: accept the full common ASCII symbol set (string.punctuation) instead of only [@$!%*?&], matching the app's accepted characters. e.g. "Welcome#2024" / "MyPass_1234" now register.
- fullName: allow Unicode letters plus spaces, periods, apostrophes and hyphens via a field validator instead of the ASCII-only ^[a-zA-Z\s'-]+$ pattern, so international names and initials (e.g. "José García", "John A. Smith") are accepted. Digits/symbols still rejected.
- error handler: include the failing field name and message in the log line so log aggregators (CloudWatch) reveal which field failed instead of only a count.

Adds tests for the widened password set, international names, rejected inputs, and the validation-error log contents.