### PR TITLE
fix: guard device registration against bad tokens and SNS failures

### DIFF
--- a/src/app/api/routes.py
+++ b/src/app/api/routes.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any, Dict, Optional
+import re
+from typing import Any, Dict, Optional, Tuple
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -37,6 +38,54 @@ sns_service = SNSService()
 dynamodb_service = get_dynamodb_service()
 user_service = UserService()
 echo_service = get_echo_service()
+
+# Device registration guards ------------------------------------------------
+# SNS rejects an APNs token that isn't hex or exceeds 400 chars. Older iOS app
+# builds sent the Firebase FCM token here, which SNS rejected with
+# InvalidParameter -> the route used to turn that into a 500. Validate at the
+# boundary instead so a bad client payload is a clean 400.
+SUPPORTED_PLATFORMS = {"ios", "android"}
+MAX_IOS_TOKEN_HEX_LENGTH = 400  # AWS SNS APNS limit
+_HEX_TOKEN_RE = re.compile(r"^[0-9a-fA-F]+$")
+
+
+def normalize_device_registration(device_token: str, platform: str) -> Tuple[str, str]:
+    """Validate and normalize a device registration payload.
+
+    Returns ``(normalized_token, normalized_platform)``.
+
+    Raises:
+        HTTPException: 400 for an unsupported platform, an empty token, or an
+            iOS token that is not a hexadecimal APNs token within the SNS limit.
+    """
+    normalized_platform = (platform or "").strip().lower()
+    if normalized_platform not in SUPPORTED_PLATFORMS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unsupported platform '{platform}'. "
+                f"Expected one of: {sorted(SUPPORTED_PLATFORMS)}"
+            ),
+        )
+
+    # APNs tokens sometimes arrive wrapped like "<abcd 1234>"; unwrap before
+    # validating so a cosmetically-formatted-but-valid token isn't rejected.
+    token = (device_token or "").strip().strip("<>").replace(" ", "")
+    if not token:
+        raise HTTPException(status_code=400, detail="device_token must not be empty")
+
+    if normalized_platform == "ios":
+        if not _HEX_TOKEN_RE.match(token) or len(token) > MAX_IOS_TOKEN_HEX_LENGTH:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Invalid iOS device token: expected a hexadecimal APNs token "
+                    f"of at most {MAX_IOS_TOKEN_HEX_LENGTH} characters. "
+                    "A Firebase/FCM token is not a valid APNs token."
+                ),
+            )
+
+    return token, normalized_platform
 
 
 class UpdateProfileRequest(BaseModel):
@@ -198,8 +247,13 @@ async def register_device(
 ):
     """Register a device for push notifications (Requires Auth)"""
     user_id = current_user["id"]
-    device_token = request.device_token
-    platform = request.platform
+
+    # Validate/normalize before any AWS call. A malformed token (e.g. an FCM
+    # token from an old iOS build) is a clean 400, not a 500. Raised here so it
+    # is not swallowed by the generic handler below.
+    device_token, platform = normalize_device_registration(
+        request.device_token, request.platform
+    )
 
     try:
         # Step 1: Check if we already have this registration in DB
@@ -219,10 +273,26 @@ async def register_device(
                 },
             }
 
-        # Step 2: Create new endpoint in SNS
-        endpoint_arn = sns_service.create_platform_endpoint(
-            token=device_token, platform=platform, user_id=user_id
-        )
+        # Step 2: Create new endpoint in SNS. Push registration is best-effort —
+        # if SNS rejects the token, don't fail the whole request (a 500 would
+        # break the calling flow). Return a soft result instead.
+        try:
+            endpoint_arn = sns_service.create_platform_endpoint(
+                token=device_token, platform=platform, user_id=user_id
+            )
+        except Exception as sns_error:
+            logger.error(
+                f"SNS endpoint creation failed for user {user_id} "
+                f"({platform}): {sns_error}"
+            )
+            return {
+                "success": True,
+                "data": {"status": "push_registration_failed"},
+                "message": (
+                    "Device accepted but push notifications could not be "
+                    "registered on this device."
+                ),
+            }
 
         # Step 3: Subscribe to the main topic
         try:
@@ -257,6 +327,8 @@ async def register_device(
             "message": "Device registered successfully",
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error in register_device: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/test_register_device_guard.py
+++ b/tests/test_register_device_guard.py
@@ -1,0 +1,146 @@
+"""Guard tests for POST /api/register-device.
+
+Older iOS app builds (pre-2026-06-10) sent the Firebase FCM token instead of the
+raw APNs token. Forwarded to the SNS APNS platform application, that produced
+``InvalidParameter ... iOS device tokens must be no more than 400 hexadecimal
+characters`` — which the route turned into a blanket HTTP 500.
+
+These tests pin the backend guard:
+  * unsupported platform -> 400
+  * malformed iOS token (non-hex / too long / empty) -> 400
+  * a valid iOS token still registers
+  * an Android FCM token (non-hex) is NOT hex-validated
+  * a runtime SNS failure is non-fatal (never a 500)
+"""
+
+from typing import Any, Dict, Iterator
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.app.api.routes as routes_module
+from src.app.core.security import get_current_user
+from src.app.handler import app
+
+VALID_IOS_TOKEN = "a1b2c3d4" * 8  # 64 hex chars, APNs-shaped
+FCM_LIKE_TOKEN = "cdE:APA91bFxyz_" + "z" * 180  # long, non-hex (':' '_' 'x')
+
+
+async def _fake_user() -> Dict[str, Any]:
+    return {"id": "test-user-123", "sub": "test-user-123", "email": "test@example.com"}
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    """Authed TestClient with a clean get_current_user override.
+
+    The conftest override uses a ``*args, **kwargs`` signature which FastAPI
+    misreads as required query params on authenticated routes, so we set our own.
+    """
+    app.dependency_overrides[get_current_user] = _fake_user
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def _mock_persistence(monkeypatch, *, existing=None, endpoint="arn:aws:sns:end"):
+    monkeypatch.setattr(
+        routes_module.dynamodb_service,
+        "get_device_token",
+        AsyncMock(return_value=existing),
+    )
+    monkeypatch.setattr(
+        routes_module.dynamodb_service,
+        "cleanup_guest_registration",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        routes_module.dynamodb_service,
+        "save_device_token",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        routes_module.sns_service,
+        "create_platform_endpoint",
+        Mock(return_value=endpoint),
+    )
+    monkeypatch.setattr(
+        routes_module.sns_service,
+        "subscribe_to_topic",
+        Mock(return_value="arn:aws:sns:sub"),
+    )
+
+
+def test_unsupported_platform_returns_400(client):
+    resp = client.post(
+        "/api/register-device",
+        json={"device_token": VALID_IOS_TOKEN, "platform": "windows"},
+    )
+    assert resp.status_code == 400
+    assert "platform" in resp.text.lower()
+
+
+def test_ios_fcm_token_returns_400(client):
+    """The actual production failure: FCM token sent as iOS -> clean 400, not 500."""
+    resp = client.post(
+        "/api/register-device",
+        json={"device_token": FCM_LIKE_TOKEN, "platform": "ios"},
+    )
+    assert resp.status_code == 400
+    assert "token" in resp.text.lower()
+
+
+def test_ios_token_too_long_returns_400(client):
+    resp = client.post(
+        "/api/register-device",
+        json={"device_token": "a" * 401, "platform": "ios"},
+    )
+    assert resp.status_code == 400
+
+
+def test_empty_token_returns_400(client):
+    resp = client.post(
+        "/api/register-device",
+        json={"device_token": "   ", "platform": "ios"},
+    )
+    assert resp.status_code == 400
+
+
+def test_valid_ios_token_registers(client, monkeypatch):
+    _mock_persistence(monkeypatch)
+    resp = client.post(
+        "/api/register-device",
+        json={"device_token": VALID_IOS_TOKEN, "platform": "ios"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"]["status"] == "registered"
+
+
+def test_android_fcm_token_allowed(client, monkeypatch):
+    """Android FCM tokens are non-hex and must not be rejected by the iOS check."""
+    _mock_persistence(monkeypatch)
+    resp = client.post(
+        "/api/register-device",
+        json={"device_token": FCM_LIKE_TOKEN, "platform": "android"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"]["status"] == "registered"
+
+
+def test_sns_failure_is_non_fatal(client, monkeypatch):
+    _mock_persistence(monkeypatch)
+    monkeypatch.setattr(
+        routes_module.sns_service,
+        "create_platform_endpoint",
+        Mock(side_effect=Exception("InvalidParameter: CreatePlatformEndpoint")),
+    )
+    resp = client.post(
+        "/api/register-device",
+        json={"device_token": VALID_IOS_TOKEN, "platform": "ios"},
+    )
+    assert resp.status_code != 500
+    assert resp.status_code == 200
+    assert resp.json()["data"]["status"] == "push_registration_failed"


### PR DESCRIPTION
POST /api/register-device returned HTTP 500 when SNS rejected the device token. Root cause: older iOS app builds (pre-2026-06-10) sent the Firebase FCM token instead of the raw APNs token; SNS's APNS platform application rejects it with "iOS device tokens must be no more than 400 hexadecimal characters", and the route wrapped any error as a 500.

- Validate/normalize the payload before any AWS call: restrict platform to ios/android and require iOS tokens to be hexadecimal and within the SNS 400-char limit. Bad input now returns a clear 400 instead of 500.
- Unwrap "<...>"-wrapped and whitespaced APNs tokens before validating.
- Make SNS endpoint creation non-fatal: on failure, log and return a soft "push_registration_failed" result so the calling flow isn't broken.
- Re-raise HTTPException so 4xx isn't masked as 500.

Adds tests for unsupported platform, FCM-as-iOS, oversized/empty tokens, the happy path, Android FCM acceptance, and non-fatal SNS failure.