### PR TITLE
fix: send SECRET_HASH on Cognito token refresh

### DIFF
--- a/src/app/api/models.py
+++ b/src/app/api/models.py
@@ -60,6 +60,11 @@ class ResetPasswordRequest(BaseModel):
 
 class RefreshTokenRequest(BaseModel):
     refreshToken: str = Field(min_length=1)
+    # Cognito username (the token's `username` claim). Required only when the
+    # app client has a secret, to compute SECRET_HASH for REFRESH_TOKEN_AUTH.
+    # Treated as untrusted: used solely to derive the HMAC, never for authz.
+    # Bounded to Cognito's 128-char username limit as defense-in-depth.
+    username: Optional[str] = Field(default=None, max_length=128)
 
 
 class EmailVerificationRequest(BaseModel):

--- a/src/app/controllers/auth_controller.py
+++ b/src/app/controllers/auth_controller.py
@@ -174,9 +174,10 @@ class AuthController:
 
     async def refresh_token(self, payload: RefreshTokenRequest) -> AuthResponse:
         """Refresh access token using refresh token"""
-        # Refresh token with Cognito
+        # Refresh token with Cognito. Pass the username so SECRET_HASH can be
+        # computed when the app client has a secret.
         auth_result = await self.cognito_service.refresh_access_token(
-            payload.refreshToken
+            payload.refreshToken, username=payload.username
         )
 
         return AuthResponse(

--- a/src/app/services/cognito_service.py
+++ b/src/app/services/cognito_service.py
@@ -333,15 +333,22 @@ class CognitoService:
             logger.exception(f"Unexpected error during resend confirmation: {str(e)}")
             raise CognitoServiceError(f"Resend confirmation failed: {str(e)}")
 
-    async def refresh_access_token(self, refresh_token: str) -> Dict[str, Any]:
-        """Refresh access token using refresh token"""
+    async def refresh_access_token(
+        self, refresh_token: str, username: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Refresh access token using refresh token.
+
+        Args:
+            refresh_token: The Cognito refresh token (the validated credential).
+            username: The user's Cognito username (the token's ``username``
+                claim). When the app client has a secret, Cognito requires
+                SECRET_HASH on REFRESH_TOKEN_AUTH, computed from this username.
+                It is untrusted input used solely to derive the HMAC — never for
+                authorization. A wrong value only yields a Cognito rejection.
+        """
         try:
             logger.info("Starting refresh token operation")
 
-            # SECRET_HASH is NOT included for refresh token operations:
-            # 1. Cognito validates the refresh token itself without needing SECRET_HASH
-            # 2. Computing it with an empty username generates an invalid hash that
-            #    causes "SecretHash does not match" / NotAuthorizedException errors
             params: Dict[str, Any] = {
                 "ClientId": self.client_id,
                 "AuthFlow": "REFRESH_TOKEN_AUTH",
@@ -349,6 +356,22 @@ class CognitoService:
                     "REFRESH_TOKEN": refresh_token,
                 },
             }
+
+            # Cognito requires SECRET_HASH for REFRESH_TOKEN_AUTH when the app
+            # client is configured with a secret. Without a username we cannot
+            # compute it; the caller is expected to supply one in that case.
+            if self.client_secret and username:
+                secret_hash = self._get_secret_hash(username)
+                if secret_hash:
+                    params["AuthParameters"]["SECRET_HASH"] = secret_hash
+            elif self.client_secret and not username:
+                # Cognito will reject this with "SECRET_HASH was not received".
+                # Log (without any PII) so the cause is obvious in CloudWatch.
+                logger.warning(
+                    "Refresh called without a username but the app client has a "
+                    "secret; SECRET_HASH cannot be computed and Cognito will "
+                    "reject the request."
+                )
 
             msg = (
                 "Refresh token params: "

--- a/tests/test_refresh_secret_hash.py
+++ b/tests/test_refresh_secret_hash.py
@@ -1,0 +1,116 @@
+"""SECRET_HASH on REFRESH_TOKEN_AUTH (Cognito refresh fix).
+
+Production refresh failed with 401: "Client is configured with secret but
+SECRET_HASH was not received". When the app client has a secret, Cognito
+requires SECRET_HASH on REFRESH_TOKEN_AUTH, computed from the user's username.
+
+Guardrails verified here:
+  * SECRET_HASH is added only when both a client secret and a username exist.
+  * The username is used ONLY to derive the HMAC (never logged, never used for
+    authz — the refresh token stays the validated credential).
+  * Neither the refresh token, the username, nor the SECRET_HASH is logged.
+"""
+
+import logging
+from unittest.mock import AsyncMock, Mock
+
+from src.app.api.models import RefreshTokenRequest
+from src.app.controllers.auth_controller import AuthController
+from src.app.services.cognito_service import CognitoService
+
+_REFRESH_RESULT = {
+    "AuthenticationResult": {
+        "AccessToken": "new-access",
+        "IdToken": "new-id",
+        "RefreshToken": "new-refresh",
+    }
+}
+
+
+def _service(client_secret):
+    svc = CognitoService()
+    svc.client_id = "test-client-id"
+    svc.client_secret = client_secret
+    svc.client = Mock()
+    svc.client.initiate_auth = Mock(return_value=_REFRESH_RESULT)
+    return svc
+
+
+async def test_secret_hash_added_when_secret_and_username():
+    svc = _service("topsecret")
+
+    await svc.refresh_access_token("refresh-tok", username="user@example.com")
+
+    params = svc.client.initiate_auth.call_args.kwargs
+    auth_params = params["AuthParameters"]
+    assert params["AuthFlow"] == "REFRESH_TOKEN_AUTH"
+    assert auth_params["REFRESH_TOKEN"] == "refresh-tok"
+    assert auth_params["SECRET_HASH"] == svc._get_secret_hash("user@example.com")
+
+
+async def test_no_secret_hash_without_username():
+    """Back-compat: no username -> no SECRET_HASH (e.g. a public client)."""
+    svc = _service("topsecret")
+
+    await svc.refresh_access_token("refresh-tok")
+
+    auth_params = svc.client.initiate_auth.call_args.kwargs["AuthParameters"]
+    assert "SECRET_HASH" not in auth_params
+
+
+async def test_no_secret_hash_without_client_secret():
+    svc = _service(None)
+
+    await svc.refresh_access_token("refresh-tok", username="user@example.com")
+
+    auth_params = svc.client.initiate_auth.call_args.kwargs["AuthParameters"]
+    assert "SECRET_HASH" not in auth_params
+
+
+async def test_refresh_does_not_log_secrets(caplog):
+    svc = _service("topsecret")
+    secret_hash = svc._get_secret_hash("user@example.com")
+
+    with caplog.at_level(logging.DEBUG):
+        await svc.refresh_access_token(
+            "super-secret-refresh", username="user@example.com"
+        )
+
+    logs = " ".join(r.getMessage() for r in caplog.records)
+    assert secret_hash not in logs
+    assert "super-secret-refresh" not in logs
+    assert "user@example.com" not in logs
+
+
+async def test_controller_threads_username_through():
+    controller = AuthController()
+    controller.cognito_service = Mock()
+    controller.cognito_service.refresh_access_token = AsyncMock(
+        return_value={
+            "accessToken": "a",
+            "refreshToken": "r",
+            "idToken": "i",
+        }
+    )
+
+    await controller.refresh_token(
+        RefreshTokenRequest(refreshToken="r", username="user@example.com")
+    )
+
+    controller.cognito_service.refresh_access_token.assert_awaited_once_with(
+        "r", username="user@example.com"
+    )
+
+
+def test_refresh_request_username_is_optional():
+    assert RefreshTokenRequest(refreshToken="r").username is None
+    assert RefreshTokenRequest(refreshToken="r", username="u").username == "u"
+
+
+def test_refresh_request_username_bounded_to_128_chars():
+    import pytest
+    from pydantic import ValidationError
+
+    RefreshTokenRequest(refreshToken="r", username="x" * 128)  # ok
+    with pytest.raises(ValidationError):
+        RefreshTokenRequest(refreshToken="r", username="x" * 129)


### PR DESCRIPTION
POST /api/auth/refresh failed in production with 401:
  "Client <id> is configured with secret but SECRET_HASH was not received"

The app client has a secret, so Cognito requires SECRET_HASH on REFRESH_TOKEN_AUTH (computed from the user's username), but the refresh call omitted it on a wrong assumption. Login worked only because it does send SECRET_HASH.

This is a backend-for-frontend: the mobile app calls this API, and the backend is the confidential Cognito client holding the secret. So the fix keeps the secret server-side and adds SECRET_HASH to refresh.

- refresh_access_token accepts an optional username and adds SECRET_HASH when both a client secret and username are present.
- RefreshTokenRequest gains an optional username (max_length=128), passed through by the controller. The username is untrusted input used only to derive the HMAC, never for authorization; the refresh token remains the validated credential, so a wrong username only yields a Cognito rejection.
- Warn (no PII) when a secret is configured but no username is supplied.

Security-reviewed (no auth bypass/enumeration/oracle; secret stays server-side; uniform error responses; no token/username/SECRET_HASH in logs) and bandit-clean. Adds tests for SECRET_HASH inclusion/omission, no-secret-logging, controller pass-through, and the username bound.

Note: the mobile app must send its token's `username` claim on refresh.