### PR TITLE
fix: harden archetype quiz submission scoring

### DIFF
--- a/src/app/api/mirrorgpt_routes.py
+++ b/src/app/api/mirrorgpt_routes.py
@@ -578,8 +578,8 @@ async def submit_archetype_quiz(
     import os
     from pathlib import Path
 
-    from ..services.quiz_scoring import QuizAnswer as ScoringQuizAnswer
     from ..services.quiz_scoring import calculate_quiz_result
+    from ..services.quiz_submission import build_scoring_inputs
 
     try:
         # 1. Determine user ID
@@ -631,9 +631,12 @@ async def submit_archetype_quiz(
         # 3. Extract quiz config for dynamic scoring
         quiz_config = questions_json.get("config", {})
 
-        # Build list of core question IDs from question data (dynamic)
+        # Build list of core question IDs from question data (dynamic).
+        # Coerce to int (DynamoDB returns numbers as Decimal).
         core_question_ids = [
-            q.get("id") for q in questions_list if q.get("core", False)
+            int(q["id"])
+            for q in questions_list
+            if q.get("core", False) and q.get("id") is not None
         ]
         if not core_question_ids:
             # Fallback to default if no core questions specified
@@ -643,68 +646,15 @@ async def submit_archetype_quiz(
         if quiz_config and "coreQuestions" not in quiz_config:
             quiz_config["coreQuestions"] = core_question_ids
 
-        # 4. Build question ID to archetype mapping
-        # Map: {question_id: {answer_text: archetype}}
-        question_map = {}
-        for q in questions_list:
-            q_id = q.get("id")
-            options = q.get("options", [])
-            question_map[q_id] = {
-                opt.get("text") or opt.get("label"): opt.get("archetype")
-                for opt in options
-            }
+        # 4. Map + validate answers (dedupe, completeness, robust extraction).
+        #    Core flag follows the configured core questions, not a hardcoded set.
+        scoring_answers, quiz_answers_for_storage = build_scoring_inputs(
+            request.answers, questions_list, core_question_ids
+        )
 
-        # 5. Map user answers to archetypes using question data
-        scoring_answers: List[ScoringQuizAnswer] = []
-        quiz_answers_for_storage = []  # For DynamoDB storage
-
-        for answer in request.answers:
-            q_id = answer.questionId
-            answer_text = None
-
-            # Extract answer text based on type
-            if isinstance(answer.answer, dict):
-                answer_text = answer.answer.get("label", "")
-            else:
-                answer_text = str(answer.answer)
-
-            # Look up archetype from question options
-            if q_id not in question_map:
-                raise HTTPException(
-                    status_code=400, detail=f"Question {q_id} not found in quiz data"
-                )
-
-            archetype = question_map[q_id].get(answer_text)
-            if not archetype:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Answer '{answer_text}' not valid for question {q_id}",
-                )
-
-            # Create scoring answer
-            is_core = q_id in [1, 3, 5]  # Q1, Q3, Q5 are core
-            scoring_answer = ScoringQuizAnswer(
-                question_id=q_id,
-                question=answer.question,
-                archetype=archetype,
-                is_core=is_core,
-            )
-            scoring_answers.append(scoring_answer)
-
-            # Store for database
-            quiz_answers_for_storage.append(
-                {
-                    "question_id": q_id,
-                    "question": answer.question,
-                    "answer": answer_text,
-                    "archetype": archetype,
-                    "answered_at": answer.answeredAt,
-                    "type": answer.type,
-                }
-            )
-
-        # 5. Calculate quiz result using V1 weighted scoring
-        quiz_result = calculate_quiz_result(scoring_answers)
+        # 5. Calculate quiz result using the quiz's own config (weights, core
+        #    questions, tie-break order) rather than the hardcoded defaults.
+        quiz_result = calculate_quiz_result(scoring_answers, quiz_config)
 
         # 7. Create initial archetype profile with calculated result
         result = await orchestrator.create_initial_archetype_profile(

--- a/src/app/services/quiz_submission.py
+++ b/src/app/services/quiz_submission.py
@@ -1,0 +1,138 @@
+"""Map and validate submitted quiz answers before scoring.
+
+Pulled out of the route handler so the mapping/validation logic is pure and
+unit-testable. Responsibilities:
+
+- Robustly extract the selected option text from text, ImageAnswer, or dict
+  answers (an image answer is a pydantic model, not a dict).
+- De-duplicate answers by question id, keeping the user's last choice, so a
+  double-submit can't double-count a question or trigger a false core override.
+- Reject incomplete submissions (every quiz question must be answered),
+  unknown questions, and invalid options with HTTP 400.
+- Derive each answer's ``is_core`` flag from the configured core questions
+  rather than a hardcoded [1, 3, 5].
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from fastapi import HTTPException
+
+from ..api.models import ImageAnswer, QuizAnswer
+from .quiz_scoring import QuizAnswer as ScoringQuizAnswer
+
+
+def _question_id(raw: Any) -> Optional[int]:
+    """Coerce a question id to int (DynamoDB returns numbers as Decimal)."""
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_answer_text(answer: QuizAnswer) -> str:
+    """Return the selected option's display text for any answer shape."""
+    value = answer.answer
+    if isinstance(value, ImageAnswer):
+        return value.label
+    if isinstance(value, dict):
+        return value.get("label") or value.get("text") or ""
+    return str(value)
+
+
+def _dedupe_keep_last(answers: List[QuizAnswer]) -> List[QuizAnswer]:
+    """Keep one answer per question id (the last submitted), in id order.
+
+    A well-behaved client sends a single answer per question. Duplicates — seen
+    in production from rapid re-submits — would otherwise be scored multiple
+    times. The latest answer is treated as the user's final choice.
+    """
+    by_qid: Dict[int, QuizAnswer] = {}
+    for answer in answers:
+        by_qid[answer.questionId] = answer
+    return [by_qid[qid] for qid in sorted(by_qid)]
+
+
+def build_scoring_inputs(
+    answers: List[QuizAnswer],
+    questions_list: List[Dict[str, Any]],
+    core_question_ids: List[int],
+) -> Tuple[List[ScoringQuizAnswer], List[Dict[str, Any]]]:
+    """Validate answers and map them to archetypes.
+
+    Args:
+        answers: Raw submitted answers.
+        questions_list: Quiz questions (id, options, ...) from DynamoDB/JSON.
+        core_question_ids: Ids of the core (higher-weight) questions.
+
+    Returns:
+        (scoring_answers, storage_answers).
+
+    Raises:
+        HTTPException: 400 for incomplete submissions, unknown questions, or
+            invalid options.
+    """
+    # question_id -> {option_text: archetype}
+    question_map: Dict[int, Dict[str, str]] = {}
+    for question in questions_list:
+        q_id = _question_id(question.get("id"))
+        if q_id is None:
+            continue
+        question_map[q_id] = {
+            (opt.get("text") or opt.get("label")): opt.get("archetype")
+            for opt in question.get("options", [])
+        }
+
+    deduped = _dedupe_keep_last(answers)
+    answered_ids = {a.questionId for a in deduped}
+
+    # Completeness: every quiz question must be answered (spec V1).
+    required_ids = set(question_map)
+    missing = required_ids - answered_ids
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Incomplete submission: missing answers for "
+                f"questions {sorted(missing)}"
+            ),
+        )
+
+    core_set = set(core_question_ids)
+    scoring_answers: List[ScoringQuizAnswer] = []
+    storage_answers: List[Dict[str, Any]] = []
+
+    for answer in deduped:
+        q_id = answer.questionId
+        if q_id not in question_map:
+            raise HTTPException(
+                status_code=400, detail=f"Question {q_id} not found in quiz data"
+            )
+
+        answer_text = _extract_answer_text(answer)
+        archetype = question_map[q_id].get(answer_text)
+        if not archetype:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Answer '{answer_text}' not valid for question {q_id}",
+            )
+
+        scoring_answers.append(
+            ScoringQuizAnswer(
+                question_id=q_id,
+                question=answer.question,
+                archetype=archetype,
+                is_core=q_id in core_set,
+            )
+        )
+        storage_answers.append(
+            {
+                "question_id": q_id,
+                "question": answer.question,
+                "answer": answer_text,
+                "archetype": archetype,
+                "answered_at": answer.answeredAt,
+                "type": answer.type,
+            }
+        )
+
+    return scoring_answers, storage_answers

--- a/tests/test_quiz_submission.py
+++ b/tests/test_quiz_submission.py
@@ -1,0 +1,156 @@
+"""Unit tests for quiz answer mapping/validation (quiz-scoring hardening).
+
+Covers:
+  #6 core flag derived from the configured core questions (not hardcoded 1/3/5)
+  #7 duplicate answers per question are de-duplicated (keep last)
+  #8 robust answer-text extraction for text, ImageAnswer model, and dict
+  #9 incomplete submissions (a quiz question unanswered) are rejected
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from src.app.api.models import ImageAnswer, QuizAnswer
+from src.app.services.quiz_submission import (
+    _dedupe_keep_last,
+    _extract_answer_text,
+    build_scoring_inputs,
+)
+
+QUESTIONS = [
+    {
+        "id": 1,
+        "question": "Q1",
+        "core": True,
+        "type": "text",
+        "options": [
+            {"text": "aha", "archetype": "Seeker"},
+            {"text": "care", "archetype": "Guardian"},
+        ],
+    },
+    {
+        "id": 2,
+        "question": "Q2",
+        "core": False,
+        "type": "image",
+        "options": [
+            {"label": "crystal", "image": "crystal", "archetype": "Seeker"},
+            {"label": "candle", "image": "candle", "archetype": "Guardian"},
+        ],
+    },
+    {
+        "id": 3,
+        "question": "Q3",
+        "core": True,
+        "type": "text",
+        "options": [
+            {"text": "grow", "archetype": "Seeker"},
+            {"text": "connect", "archetype": "Guardian"},
+        ],
+    },
+]
+
+CORE_IDS = [1, 3]
+
+
+def _ans(qid, answer, type_="text", at="2026-01-01T00:00:00Z"):
+    return QuizAnswer(
+        questionId=qid, question=f"Q{qid}", answer=answer, answeredAt=at, type=type_
+    )
+
+
+def _full_text_answers():
+    return [_ans(1, "aha"), _ans(2, "crystal", "image"), _ans(3, "grow")]
+
+
+def test_happy_path_maps_archetypes_and_core_flag():
+    scoring, storage = build_scoring_inputs(_full_text_answers(), QUESTIONS, CORE_IDS)
+
+    assert [s["archetype"] for s in scoring] == ["Seeker", "Seeker", "Seeker"]
+    # #6: is_core derived from CORE_IDS, not a hardcoded [1,3,5]
+    assert {s["question_id"]: s["is_core"] for s in scoring} == {
+        1: True,
+        2: False,
+        3: True,
+    }
+    assert len(storage) == 3
+    assert storage[0]["answer"] == "aha"
+    assert storage[1]["archetype"] == "Seeker"
+
+
+def test_core_flag_follows_configured_core_questions():
+    # #6: a quiz whose core questions are [2] must mark q2 core, not q1/q3.
+    scoring, _ = build_scoring_inputs(_full_text_answers(), QUESTIONS, [2])
+    assert {s["question_id"]: s["is_core"] for s in scoring} == {
+        1: False,
+        2: True,
+        3: False,
+    }
+
+
+def test_image_answer_model_extracted_by_label():
+    # #8: ImageAnswer is a pydantic model, not a dict — must still map by label.
+    answers = [
+        _ans(1, "aha"),
+        _ans(2, ImageAnswer(label="candle", image="candle"), "image"),
+        _ans(3, "grow"),
+    ]
+    scoring, _ = build_scoring_inputs(answers, QUESTIONS, CORE_IDS)
+    by_id = {s["question_id"]: s["archetype"] for s in scoring}
+    assert by_id[2] == "Guardian"
+
+
+def test_image_answer_dict_extracted_by_label():
+    assert (
+        _extract_answer_text(_ans(2, {"label": "candle", "image": "c"}, "image"))
+        == "candle"
+    )
+
+
+def test_extract_text_variants():
+    assert _extract_answer_text(_ans(1, "aha")) == "aha"
+    assert (
+        _extract_answer_text(_ans(2, ImageAnswer(label="crystal", image="c")))
+        == "crystal"
+    )
+
+
+def test_duplicate_answers_keep_last():
+    # #7: two answers for q3 -> last one wins, counted once.
+    answers = [
+        _ans(1, "aha"),
+        _ans(2, "crystal", "image"),
+        _ans(3, "grow"),
+        _ans(3, "connect"),  # user changed their mind / double submit
+    ]
+    deduped = _dedupe_keep_last(answers)
+    assert [a.questionId for a in deduped] == [1, 2, 3]
+
+    scoring, _ = build_scoring_inputs(answers, QUESTIONS, CORE_IDS)
+    q3 = next(s for s in scoring if s["question_id"] == 3)
+    assert q3["archetype"] == "Guardian"  # last answer ("connect")
+    assert len([s for s in scoring if s["question_id"] == 3]) == 1
+
+
+def test_incomplete_submission_rejected():
+    # #9: missing q2 -> 400
+    answers = [_ans(1, "aha"), _ans(3, "grow")]
+    with pytest.raises(HTTPException) as exc:
+        build_scoring_inputs(answers, QUESTIONS, CORE_IDS)
+    assert exc.value.status_code == 400
+    assert "2" in str(exc.value.detail)
+
+
+def test_unknown_question_rejected():
+    answers = _full_text_answers() + [_ans(99, "aha")]
+    with pytest.raises(HTTPException) as exc:
+        build_scoring_inputs(answers, QUESTIONS, CORE_IDS)
+    assert exc.value.status_code == 400
+
+
+def test_invalid_option_rejected():
+    answers = [_ans(1, "not-an-option"), _ans(2, "crystal", "image"), _ans(3, "grow")]
+    with pytest.raises(HTTPException) as exc:
+        build_scoring_inputs(answers, QUESTIONS, CORE_IDS)
+    assert exc.value.status_code == 400
+    assert "not valid" in str(exc.value.detail)

--- a/tests/test_quiz_submit_route.py
+++ b/tests/test_quiz_submit_route.py
@@ -1,0 +1,101 @@
+"""Route-level guards for POST /api/mirrorgpt/quiz/submit (hardening bundle).
+
+Exercises the endpoint end-to-end (falling back to the bundled questions.json):
+  #9 an incomplete submission is rejected with 400
+  #7 duplicate answers for a question are scored once (last wins)
+  #5 the full 5-answer happy path still scores correctly through the config path
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app.api.mirrorgpt_routes import get_dynamodb_service, get_mirror_orchestrator
+from src.app.handler import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def overrides():
+    db = AsyncMock()
+    db.get_quiz_questions = AsyncMock(return_value=None)  # -> questions.json fallback
+    orch = AsyncMock()
+    orch.create_initial_archetype_profile = AsyncMock(
+        return_value={"success": True, "profile_created": True}
+    )
+    app.dependency_overrides[get_dynamodb_service] = lambda: db
+    app.dependency_overrides[get_mirror_orchestrator] = lambda: orch
+    try:
+        yield orch
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _answer(qid, text, at_suffix="00"):
+    return {
+        "questionId": qid,
+        "question": f"Q{qid}",
+        "answer": text,
+        "answeredAt": f"2026-04-19T10:00:{at_suffix}Z",
+        "type": "text" if qid != 2 else "image",
+    }
+
+
+# Canonical answers that map to Seeker on the bundled questions.json.
+SEEKER_ANSWERS = [
+    _answer(1, "A quiet aha when something finally clicks", "00"),
+    _answer(2, "A glowing crystal sphere", "10"),
+    _answer(3, "I want to understand myself better.", "20"),
+    _answer(4, "I give them clarity or insight they didn't see before.", "30"),
+    _answer(5, "I'm here to learn and grow.", "40"),
+]
+
+
+def _request(answers):
+    return {
+        "quiz_type": "archetype",
+        "answers": answers,
+        "completedAt": "2026-04-19T10:00:40Z",
+        "quizVersion": "1.0",
+        "anonymousId": "test123",
+    }
+
+
+def test_incomplete_submission_returns_400(client, overrides):
+    # Missing Q5 -> reject (#9)
+    resp = client.post("/api/mirrorgpt/quiz/submit", json=_request(SEEKER_ANSWERS[:4]))
+    assert resp.status_code == 400
+    assert "missing" in resp.text.lower()
+
+
+def test_full_submission_scores_seeker(client, overrides):
+    # #5: full set scores correctly via the config-driven path.
+    resp = client.post("/api/mirrorgpt/quiz/submit", json=_request(SEEKER_ANSWERS))
+    assert resp.status_code == 200
+    assert resp.json()["data"]["final_archetype"] == "Seeker"
+
+
+def test_duplicate_answer_scored_once(client, overrides):
+    # #7: a duplicate Q5 (Guardian then Seeker) must not double-count; the
+    # last answer wins and the result stays a clean Seeker core override.
+    answers = [
+        SEEKER_ANSWERS[0],
+        SEEKER_ANSWERS[1],
+        SEEKER_ANSWERS[2],
+        SEEKER_ANSWERS[3],
+        _answer(5, "I'm here to care and connect.", "40"),  # Guardian (superseded)
+        _answer(5, "I'm here to learn and grow.", "45"),  # Seeker (final)
+    ]
+    resp = client.post("/api/mirrorgpt/quiz/submit", json=_request(answers))
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["final_archetype"] == "Seeker"
+    # The superseded Guardian answer for Q5 must NOT be counted — without dedup
+    # it would add 2 points to Guardian. Seeker stays 8 (all 5 answers Seeker).
+    assert data["total_scores"]["Guardian"] == 0
+    assert data["total_scores"]["Seeker"] == 8


### PR DESCRIPTION
Bundles five quiz-scoring fixes in the /mirrorgpt/quiz/submit path. The mapping/validation logic moves to a pure, unit-tested helper (services/quiz_submission.py); the route keeps only I/O.

- #5 pass the quiz's own config (weights, core questions, tie-break order) to calculate_quiz_result instead of silently using the hardcoded defaults.
- #6 derive each answer's is_core flag from the configured core questions rather than a hardcoded [1, 3, 5].
- #7 de-duplicate answers by question id (keep the user's last choice) so a double-submit can't double-count a question or trigger a false core override.
- #8 robustly extract the selected option text for text, ImageAnswer (a pydantic model, not a dict), and dict answers.
- #9 reject incomplete submissions (every quiz question must be answered), unknown questions, and invalid options with HTTP 400.

Also coerce question ids to int at the boundary (DynamoDB returns Decimal).

Adds unit tests for the helper (mapping, dedupe, completeness, core flag, image extraction) and route-level tests (incomplete -> 400, dedupe end-to-end, full happy path through the config-driven scorer).