### PR TITLE
feat: correlation IDs in every log line + sanitize auth PII

### DIFF
--- a/src/app/controllers/auth_controller.py
+++ b/src/app/controllers/auth_controller.py
@@ -19,6 +19,7 @@ from ..api.models import (
     UserBasic,
     UserRegistrationRequest,
 )
+from ..core.log_sanitize import mask_email
 from ..services.cognito_service import get_cognito_service
 from ..services.dynamodb_service import get_dynamodb_service
 from ..services.echo_service import get_echo_service
@@ -322,7 +323,7 @@ class AuthController:
             if user_email:
                 try:
                     await self.cognito_service.admin_user_global_sign_out(user_email)
-                    logger.info(f"User signed out globally: {user_email}")
+                    logger.info(f"User signed out globally: {mask_email(user_email)}")
                 except Exception as e:
                     # Don't fail logout if global sign out fails
                     logger.warning(f"Failed to sign out user globally: {e}")
@@ -343,7 +344,7 @@ class AuthController:
         if user_email and user_id:
             try:
                 await self.cognito_service.admin_delete_user(user_email)
-                logger.info(f"Deleted user from Cognito: {user_email}")
+                logger.info(f"Deleted user from Cognito: {mask_email(user_email)}")
 
                 # Then delete from DynamoDB
                 await self.user_service.delete_user_account(user_id)

--- a/src/app/core/error_handlers.py
+++ b/src/app/core/error_handlers.py
@@ -14,6 +14,12 @@ from fastapi.responses import JSONResponse
 from starlette.responses import Response
 
 from .exceptions import BaseAPIException
+from .request_context import (
+    reset_request_id,
+    reset_user_id,
+    set_request_id,
+    set_user_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +86,6 @@ async def base_api_exception_handler(request: Request, exc: Exception) -> Respon
     logger.error(
         f"API Exception: {exc.__class__.__name__}: {exc.message}",
         extra={
-            "request_id": request_id,
             "path": request.url.path,
             "method": request.method,
             "status_code": exc.status_code,
@@ -137,7 +142,6 @@ async def http_exception_handler(request: Request, exc: Exception) -> Response:
     logger.warning(
         f"HTTP Exception: {exc.status_code}: {exc.detail}",
         extra={
-            "request_id": request_id,
             "path": request.url.path,
             "method": request.method,
             "status_code": exc.status_code,
@@ -181,7 +185,6 @@ async def validation_exception_handler(request: Request, exc: Exception) -> Resp
         f"Validation Error on {request.method} {request.url.path}: "
         f"{len(validation_errors)} error(s) - {error_summary}",
         extra={
-            "request_id": request_id,
             "path": request.url.path,
             "method": request.method,
             "validation_errors": validation_errors,
@@ -210,7 +213,6 @@ async def general_exception_handler(request: Request, exc: Exception) -> Respons
     logger.exception(
         f"Unhandled Exception: {exc.__class__.__name__}: {str(exc)}",
         extra={
-            "request_id": request_id,
             "path": request.url.path,
             "method": request.method,
         },
@@ -247,27 +249,40 @@ def setup_error_handlers(app: FastAPI):
     # Add request ID middleware
     @app.middleware("http")
     async def add_request_id(request: Request, call_next):
-        request_id = str(uuid.uuid4())
+        # Honor an inbound X-Request-ID so a trace can span services/clients;
+        # otherwise generate one. The id is bound into the logging context so
+        # every log line for this request carries it.
+        request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
         request.state.request_id = request_id
 
+        request_id_token = set_request_id(request_id)
+        # Reset user_id to default at request start; the auth dependency sets
+        # the real value once the token is decoded. Resetting here prevents a
+        # previous request's user from leaking into an unauthenticated one.
+        user_id_token = set_user_id(None)
+
         start_time = time.time()
-        response = await call_next(request)
-        process_time = (time.time() - start_time) * 1000
+        try:
+            response = await call_next(request)
+            process_time = (time.time() - start_time) * 1000
 
-        # Add request ID to response headers
-        response.headers["X-Request-ID"] = request_id
+            # Add request ID to response headers
+            response.headers["X-Request-ID"] = request_id
 
-        # Log request
-        logger.info(
-            f"{request.method} {request.url.path} - "
-            f"{response.status_code} - {process_time:.2f}ms",
-            extra={
-                "request_id": request_id,
-                "method": request.method,
-                "path": request.url.path,
-                "status_code": response.status_code,
-                "process_time_ms": process_time,
-            },
-        )
+            # Log request (still inside the bound context so the line carries
+            # this request's id/user).
+            logger.info(
+                f"{request.method} {request.url.path} - "
+                f"{response.status_code} - {process_time:.2f}ms",
+                extra={
+                    "method": request.method,
+                    "path": request.url.path,
+                    "status_code": response.status_code,
+                    "process_time_ms": process_time,
+                },
+            )
 
-        return response
+            return response
+        finally:
+            reset_user_id(user_id_token)
+            reset_request_id(request_id_token)

--- a/src/app/core/log_sanitize.py
+++ b/src/app/core/log_sanitize.py
@@ -1,0 +1,23 @@
+"""Helpers to keep PII out of logs.
+
+Use these when a log line would otherwise contain personal data (chiefly email
+addresses). They preserve enough signal to debug — a leading character and the
+domain — without writing the full address to CloudWatch.
+"""
+
+from typing import Any
+
+
+def mask_email(email: Any) -> str:
+    """Mask an email for logging.
+
+    ``"john.doe@example.com"`` -> ``"j***@example.com"``. Keeps the first
+    character of the local part and the full domain. Returns ``"<redacted>"``
+    for anything that isn't a usable address.
+    """
+    if not isinstance(email, str) or "@" not in email:
+        return "<redacted>"
+    local, _, domain = email.partition("@")
+    if not local or not domain:
+        return "<redacted>"
+    return f"{local[0]}***@{domain}"

--- a/src/app/core/logging_config.py
+++ b/src/app/core/logging_config.py
@@ -20,6 +20,7 @@ def get_logging_config() -> Dict[str, Any]:
             "detailed": {
                 "format": (
                     "%(asctime)s - %(name)s - %(levelname)s - "
+                    "[req:%(request_id)s user:%(user_id)s] "
                     "%(message)s - [%(filename)s:%(lineno)d]"
                 ),
                 "datefmt": "%Y-%m-%d %H:%M:%S",
@@ -29,6 +30,7 @@ def get_logging_config() -> Dict[str, Any]:
                 "format": (
                     '{"time":"%(asctime)s","name":"%(name)s",'
                     '"level":"%(levelname)s","message":"%(message)s",'
+                    '"request_id":"%(request_id)s","user_id":"%(user_id)s",'
                     '"file":"%(filename)s","line":%(lineno)d}'
                 ),
                 "datefmt": "%Y-%m-%dT%H:%M:%SZ",
@@ -81,6 +83,12 @@ def get_logging_config() -> Dict[str, Any]:
 
 def setup_logging():
     """Setup logging configuration"""
+    # Install the context record factory before configuring handlers so every
+    # record (including third-party loggers) carries request_id / user_id.
+    from .request_context import install_log_record_factory
+
+    install_log_record_factory()
+
     config = get_logging_config()
     logging.config.dictConfig(config)
 

--- a/src/app/core/request_context.py
+++ b/src/app/core/request_context.py
@@ -1,0 +1,72 @@
+"""Request-scoped logging context (correlation IDs).
+
+Holds a ``request_id`` (per HTTP request) and ``user_id`` (the authenticated
+Cognito sub) in context variables, and installs a ``logging`` record factory so
+*every* log line carries them. This makes a single request greppable end-to-end
+and lets you follow one user across requests when they report an issue.
+
+- ``request_id`` is set by the request-id middleware (honoring an inbound
+  ``X-Request-ID`` for cross-service tracing) and returned in the response.
+- ``user_id`` is set by the auth dependency once the token is decoded.
+
+Both default to ``"-"`` so unauthenticated/background log lines are still valid.
+"""
+
+import contextvars
+import logging
+from typing import Optional
+
+DEFAULT = "-"
+
+_request_id: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "request_id", default=DEFAULT
+)
+_user_id: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "user_id", default=DEFAULT
+)
+
+
+def set_request_id(value: Optional[str]) -> contextvars.Token:
+    return _request_id.set(value or DEFAULT)
+
+
+def reset_request_id(token: contextvars.Token) -> None:
+    _request_id.reset(token)
+
+
+def get_request_id() -> str:
+    return _request_id.get()
+
+
+def set_user_id(value: Optional[str]) -> contextvars.Token:
+    return _user_id.set(value or DEFAULT)
+
+
+def reset_user_id(token: contextvars.Token) -> None:
+    _user_id.reset(token)
+
+
+def get_user_id() -> str:
+    return _user_id.get()
+
+
+def install_log_record_factory() -> None:
+    """Wrap the active LogRecord factory so every record carries the context.
+
+    Idempotent: re-installing won't stack wrappers. Using a record factory
+    (rather than per-handler filters) guarantees the ``request_id``/``user_id``
+    attributes exist on every record, so formatters that reference them never
+    raise.
+    """
+    existing = logging.getLogRecordFactory()
+    if getattr(existing, "_mc_context_factory", False):
+        return
+
+    def factory(*args, **kwargs):
+        record = existing(*args, **kwargs)
+        record.request_id = _request_id.get()
+        record.user_id = _user_id.get()
+        return record
+
+    factory._mc_context_factory = True  # type: ignore[attr-defined]
+    logging.setLogRecordFactory(factory)

--- a/src/app/core/security.py
+++ b/src/app/core/security.py
@@ -10,6 +10,8 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
 
 from .exceptions import AuthenticationError, InvalidTokenError, TokenExpiredError
+from .log_sanitize import mask_email
+from .request_context import set_user_id
 
 logger = logging.getLogger(__name__)
 
@@ -218,6 +220,12 @@ def map_claims_to_profile(payload: Dict[str, Any]) -> Dict[str, Any]:
         "features": [],
     }
 
+    # Bind the user id into the logging context so every subsequent log line in
+    # this request is attributable to the user (greppable when they report an
+    # issue). All auth paths return through here.
+    sub = payload.get("sub")
+    set_user_id(sub if isinstance(sub, str) else None)
+
     return profile
 
 
@@ -306,11 +314,12 @@ async def get_current_user(
     if is_development:
         logger.info(
             f"🔧 Development: Decoded JWT token for user: "
-            f"{user_profile.get('email', 'unknown')}"
+            f"{mask_email(user_profile.get('email'))}"
         )
     else:
         logger.debug(
-            f"✅ Production: User authenticated: {user_profile.get('email', 'unknown')}"
+            f"✅ Production: User authenticated: "
+            f"{mask_email(user_profile.get('email'))}"
         )
 
     return user_profile

--- a/src/app/services/cognito_service.py
+++ b/src/app/services/cognito_service.py
@@ -22,6 +22,7 @@ from ..core.exceptions import (
     UserNotFoundError,
     ValidationError,
 )
+from ..core.log_sanitize import mask_email
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +81,10 @@ class CognitoService:
         error_code = error.response["Error"]["Code"]
         error_message = error.response["Error"]["Message"]
 
-        logger.error(f"Cognito {operation} error: {error_code} - {error_message}")
+        # Log only the (safe) error code at ERROR for alerting. The raw Cognito
+        # message can echo identifiers, so keep it at DEBUG.
+        logger.error(f"Cognito {operation} error: {error_code}")
+        logger.debug(f"Cognito {operation} error detail: {error_message}")
 
         error_mappings = {
             "UsernameExistsException": UserAlreadyExistsError(
@@ -166,7 +170,7 @@ class CognitoService:
 
             response = await asyncio.to_thread(self.client.sign_up, **params)
 
-            logger.info(f"User registered successfully: {email}")
+            logger.info(f"User registered successfully: {mask_email(email)}")
 
             return {
                 "userSub": response["UserSub"],
@@ -212,7 +216,7 @@ class CognitoService:
                     "Authentication failed - incomplete token response"
                 )
 
-            logger.info(f"User authenticated successfully: {email}")
+            logger.info(f"User authenticated successfully: {mask_email(email)}")
 
             return {
                 "accessToken": access_token,
@@ -238,7 +242,7 @@ class CognitoService:
 
             response = await asyncio.to_thread(self.client.forgot_password, **params)
 
-            logger.info(f"Password reset initiated for: {email}")
+            logger.info(f"Password reset initiated for: {mask_email(email)}")
 
             return response
 
@@ -269,7 +273,7 @@ class CognitoService:
                 self.client.confirm_forgot_password, **params
             )
 
-            logger.info(f"Password reset confirmed for: {email}")
+            logger.info(f"Password reset confirmed for: {mask_email(email)}")
 
             return response
 
@@ -299,7 +303,7 @@ class CognitoService:
 
             response = await asyncio.to_thread(self.client.confirm_sign_up, **params)
 
-            logger.info(f"Email confirmed for: {email}")
+            logger.info(f"Email confirmed for: {mask_email(email)}")
 
             return response
 
@@ -323,7 +327,7 @@ class CognitoService:
                 self.client.resend_confirmation_code, **params
             )
 
-            logger.info(f"Confirmation code resent for: {email}")
+            logger.info(f"Confirmation code resent for: {mask_email(email)}")
 
             return response
 
@@ -404,16 +408,13 @@ class CognitoService:
         except ClientError as e:
             # Custom error handling for refresh token operations
             error_code = e.response["Error"]["Code"]
-            error_message = e.response["Error"]["Message"]
 
-            logger.error(
-                f"Cognito refresh_token ClientError: {error_code} - {error_message}"
-            )
-            # Full response can carry user identifiers and Cognito-internal
-            # request IDs — keep at DEBUG so it doesn't leak into prod
-            # CloudWatch by default. Operators can raise log level when
-            # diagnosing a specific incident.
-            logger.debug(f"Full error response: {e.response}")
+            logger.error(f"Cognito refresh_token ClientError: {error_code}")
+            # The raw message and full response can carry user identifiers and
+            # Cognito-internal request IDs — keep at DEBUG so they don't leak
+            # into prod CloudWatch by default. Operators can raise the log level
+            # when diagnosing a specific incident.
+            logger.debug(f"Cognito refresh_token error detail: {e.response}")
 
             # Specific error mappings for refresh token flow
             if error_code == "NotAuthorizedException":
@@ -482,7 +483,7 @@ class CognitoService:
                 Username=email,
             )
 
-            logger.info(f"User account deleted successfully: {email}")
+            logger.info(f"User account deleted successfully: {mask_email(email)}")
 
             return response
 

--- a/tests/test_auth_log_sanitize.py
+++ b/tests/test_auth_log_sanitize.py
@@ -1,0 +1,50 @@
+"""Auth logging sanitization.
+
+Keeps PII (email) and raw Cognito error text out of production logs:
+  - mask_email masks the local part of an address.
+  - Cognito error handling logs the (safe) error code at ERROR and demotes the
+    raw Cognito message — which can echo identifiers — to DEBUG.
+"""
+
+import logging
+
+import pytest
+from botocore.exceptions import ClientError
+
+from src.app.core.exceptions import AuthenticationError
+from src.app.core.log_sanitize import mask_email
+from src.app.services.cognito_service import CognitoService
+
+
+class TestMaskEmail:
+    def test_masks_local_part_keeps_domain(self):
+        assert mask_email("john.doe@example.com") == "j***@example.com"
+
+    def test_single_char_local(self):
+        assert mask_email("a@example.com") == "a***@example.com"
+
+    @pytest.mark.parametrize("value", [None, "", "not-an-email", "@nolocal.com", 123])
+    def test_unusable_input_is_redacted(self, value):
+        assert mask_email(value) == "<redacted>"
+
+
+class TestCognitoErrorLogging:
+    def _error(self, code, message):
+        return ClientError(
+            {"Error": {"Code": code, "Message": message}}, "InitiateAuth"
+        )
+
+    def test_error_code_logged_but_not_raw_message(self, caplog):
+        svc = CognitoService()
+        secret = "user a3f9 in pool xyz failed: token leaked detail"
+
+        with caplog.at_level(logging.DEBUG):
+            with pytest.raises(AuthenticationError):
+                svc._handle_cognito_error(
+                    self._error("NotAuthorizedException", secret), "login"
+                )
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        error_text = " ".join(r.getMessage() for r in error_records)
+        assert "NotAuthorizedException" in error_text  # safe code is logged
+        assert secret not in error_text  # raw message is NOT at ERROR

--- a/tests/test_log_context.py
+++ b/tests/test_log_context.py
@@ -1,0 +1,97 @@
+"""Correlation IDs in logs (request_id + user_id).
+
+Verifies the record factory injects request_id/user_id onto every LogRecord,
+that they default to "-", reflect the context vars, and that an HTTP request
+binds a request id end-to-end (returned via X-Request-ID) without leaking
+between requests.
+"""
+
+import logging
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.app.core.error_handlers import setup_error_handlers
+from src.app.core.request_context import (
+    get_request_id,
+    get_user_id,
+    install_log_record_factory,
+    reset_request_id,
+    set_request_id,
+    set_user_id,
+)
+
+
+def test_factory_defaults_to_dash():
+    install_log_record_factory()
+    record = logging.getLogRecordFactory()("n", logging.INFO, "f", 1, "msg", None, None)
+    # request_id/user_id are injected dynamically by the factory.
+    assert getattr(record, "request_id") == "-"
+    assert getattr(record, "user_id") == "-"
+
+
+def test_factory_reflects_context():
+    install_log_record_factory()
+    rid = set_request_id("req-123")
+    uid = set_user_id("user-abc")
+    try:
+        record = logging.getLogRecordFactory()(
+            "n", logging.INFO, "f", 1, "msg", None, None
+        )
+        assert getattr(record, "request_id") == "req-123"
+        assert getattr(record, "user_id") == "user-abc"
+    finally:
+        reset_request_id(rid)
+        # user reset via fresh default
+        set_user_id(None)
+
+
+def test_install_is_idempotent():
+    install_log_record_factory()
+    first = logging.getLogRecordFactory()
+    install_log_record_factory()
+    assert logging.getLogRecordFactory() is first
+
+
+def test_set_none_is_default():
+    set_user_id(None)
+    assert get_user_id() == "-"
+    token = set_request_id("")
+    assert get_request_id() == "-"
+    reset_request_id(token)
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    setup_error_handlers(app)
+
+    @app.get("/ping")
+    async def ping():
+        return {"request_id": get_request_id()}
+
+    return app
+
+
+def test_request_binds_and_returns_request_id():
+    client = TestClient(_app())
+    resp = client.get("/ping")
+    assert resp.status_code == 200
+    # The handler saw a bound (non-default) request id...
+    body_id = resp.json()["request_id"]
+    assert body_id != "-"
+    # ...and it's echoed back in the response header.
+    assert resp.headers["X-Request-ID"] == body_id
+
+
+def test_inbound_request_id_is_honored():
+    client = TestClient(_app())
+    resp = client.get("/ping", headers={"X-Request-ID": "trace-xyz"})
+    assert resp.headers["X-Request-ID"] == "trace-xyz"
+    assert resp.json()["request_id"] == "trace-xyz"
+
+
+def test_request_id_does_not_leak_after_request():
+    client = TestClient(_app())
+    client.get("/ping", headers={"X-Request-ID": "trace-xyz"})
+    # After the request completes the context is reset to default.
+    assert get_request_id() == "-"


### PR DESCRIPTION
Adds request/user correlation to all logs and stops leaking PII and raw Cognito error text — so a reported issue can be traced end-to-end without exposing emails.

Correlation:
- request_context: contextvars for request_id + user_id and a LogRecord factory so every log line carries them (default "-").
- logging_config: install the factory and add [req:.. user:..] to the detailed/json formats.
- request-id middleware honors an inbound X-Request-ID (cross-service tracing), binds the id into the context, and resets it after the request.
- the auth dependency binds user_id (Cognito sub) once the token is decoded.

Sanitization:
- mask_email() masks the local part ("j***@example.com"); applied to the email/username log lines in cognito_service, auth_controller, security.
- Cognito error handling logs the safe error_code at ERROR and demotes the raw message (which can echo identifiers) to DEBUG.

Removed now-redundant request_id keys from logger extra= dicts to avoid the "overwrite in LogRecord" collision with the factory-provided attribute.

Adds tests for masking, error-code-only logging, the record factory, and request-id binding/echo/no-leak through a live request.