### PR TITLE
fix: mask recipient email in EmailService SES logs

### DIFF
--- a/src/app/services/email_service.py
+++ b/src/app/services/email_service.py
@@ -18,6 +18,8 @@ from botocore.config import Config
 from botocore.exceptions import ClientError
 from jinja2 import Environment, FileSystemLoader, TemplateError, select_autoescape
 
+from ..core.log_sanitize import mask_email
+
 logger = logging.getLogger(__name__)
 
 
@@ -827,15 +829,21 @@ This is an automated message from {self.app_name}.
                 )
 
                 message_id = response.get("MessageId", "unknown")
-                logger.info(f"Email sent to {to_email}, MessageId: {message_id}")
+                logger.info(
+                    f"Email sent to {mask_email(to_email)}, MessageId: {message_id}"
+                )
                 return True
 
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "Unknown")
-            logger.error(f"SES error sending email to {to_email}: {error_code} - {e}")
+            logger.error(
+                f"SES error sending email to {mask_email(to_email)}: {error_code}"
+            )
             return False
         except Exception as e:
-            logger.error(f"Unexpected error sending email to {to_email}: {e}")
+            logger.error(
+                f"Unexpected error sending email to {mask_email(to_email)}: {e}"
+            )
             return False
 
 

--- a/tests/test_email_async_boto3.py
+++ b/tests/test_email_async_boto3.py
@@ -80,3 +80,66 @@ async def test_send_email_passes_config_to_session_client():
     assert send_kwargs["Source"] == service.sender_email
     assert send_kwargs["Destination"]["ToAddresses"] == ["u@example.com"]
     assert send_kwargs["Message"]["Subject"]["Data"] == "Subj"
+
+
+def _mock_ses_cm(send_email_mock):
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=AsyncMock(send_email=send_email_mock))
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm
+
+
+@pytest.mark.asyncio
+async def test_send_email_masks_recipient_on_success(caplog):
+    """The recipient address must be masked in the success log line (no PII)."""
+    import logging
+
+    from src.app.services.email_service import EmailService
+
+    service = EmailService()
+    send = AsyncMock(return_value={"MessageId": "abc-123"})
+
+    with patch.object(service.session, "client", return_value=_mock_ses_cm(send)):
+        with caplog.at_level(logging.INFO):
+            ok = await service._send_email(
+                to_email="john.doe@example.com",
+                subject="Subj",
+                html_body="<p>Hi</p>",
+                text_body="Hi",
+            )
+
+    assert ok is True
+    logs = " ".join(r.getMessage() for r in caplog.records)
+    assert "john.doe@example.com" not in logs
+    assert "j***@example.com" in logs
+
+
+@pytest.mark.asyncio
+async def test_send_email_masks_recipient_on_error(caplog):
+    """The recipient address must be masked in the error log line too."""
+    import logging
+
+    from botocore.exceptions import ClientError
+
+    from src.app.services.email_service import EmailService
+
+    service = EmailService()
+    send = AsyncMock(
+        side_effect=ClientError(
+            {"Error": {"Code": "MessageRejected", "Message": "bad"}}, "SendEmail"
+        )
+    )
+
+    with patch.object(service.session, "client", return_value=_mock_ses_cm(send)):
+        with caplog.at_level(logging.ERROR):
+            ok = await service._send_email(
+                to_email="john.doe@example.com",
+                subject="Subj",
+                html_body="<p>Hi</p>",
+                text_body="Hi",
+            )
+
+    assert ok is False
+    logs = " ".join(r.getMessage() for r in caplog.records)
+    assert "john.doe@example.com" not in logs
+    assert "j***@example.com" in logs


### PR DESCRIPTION
Extends the auth-log PII sanitization to the email subsystem. _send_email logged the full recipient address on every send and on SES errors; mask it with mask_email (j***@example.com) and drop the raw ClientError repr from the error line (keep the safe error_code). The configured sender identity log is left as-is (app's own SES identity, useful for ops, not user PII).

Adds tests asserting the recipient is masked on both success and error paths.