### PR TITLE
perf: serve quiz questions from bundled file, not a DynamoDB scan

### DIFF
--- a/scripts/export_quiz_questions.py
+++ b/scripts/export_quiz_questions.py
@@ -1,0 +1,127 @@
+"""Export quiz questions from DynamoDB into the bundled questions.json.
+
+The archetype quiz is served from src/app/data/questions.json at runtime (no
+DynamoDB scan on the request path). This script keeps that file in sync with the
+``quiz_questions`` table: it scans the table and rewrites ONLY the ``questions``
+array, preserving the file's ``config``/``archetypes``/version metadata (which
+live only in the file, not the table).
+
+Usage:
+    python scripts/export_quiz_questions.py            # write questions.json
+    python scripts/export_quiz_questions.py --check     # exit 1 if out of sync
+
+The --check mode writes nothing; use it in CI to fail the build when someone
+edits the table without re-exporting (or vice-versa).
+"""
+
+import argparse
+import decimal
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import boto3
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
+TABLE_NAME = os.getenv(
+    "DYNAMODB_QUIZ_QUESTIONS_TABLE",
+    "mirror-collective-python-api-quiz-questions-production-v2",
+)
+QUESTIONS_FILE = (
+    Path(__file__).resolve().parent.parent / "src" / "app" / "data" / "questions.json"
+)
+
+
+def _decimals_to_native(obj: Any) -> Any:
+    """DynamoDB returns numbers as Decimal; convert to int/float for JSON."""
+    if isinstance(obj, list):
+        return [_decimals_to_native(x) for x in obj]
+    if isinstance(obj, dict):
+        return {k: _decimals_to_native(v) for k, v in obj.items()}
+    if isinstance(obj, decimal.Decimal):
+        return int(obj) if obj % 1 == 0 else float(obj)
+    return obj
+
+
+def _normalize_question(q: Dict[str, Any]) -> Dict[str, Any]:
+    """Stable shape/ordering for a question so diffs are minimal and reviewable."""
+    options = [
+        {k: opt[k] for k in ("text", "label", "image", "archetype") if k in opt}
+        for opt in q.get("options", [])
+    ]
+    out: Dict[str, Any] = {
+        "id": int(q["id"]),
+        "question": q.get("question", ""),
+        "type": q.get("type", "text"),
+        "core": bool(q.get("core", False)),
+        "options": options,
+    }
+    return out
+
+
+def fetch_table_questions(table_name: str) -> List[Dict[str, Any]]:
+    table = boto3.resource("dynamodb", region_name=AWS_REGION).Table(table_name)
+    items = _decimals_to_native(table.scan().get("Items", []))
+    items.sort(key=lambda q: int(q["id"]))
+    return [_normalize_question(q) for q in items]
+
+
+def build_updated_file(table_questions: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Merge table questions into the existing file, preserving other keys."""
+    with open(QUESTIONS_FILE, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    data["questions"] = table_questions
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 if questions.json is out of sync with the table (no write).",
+    )
+    parser.add_argument("--table", default=TABLE_NAME, help="DynamoDB table name.")
+    args = parser.parse_args()
+
+    logger.info("Fetching questions from %s (%s)", args.table, AWS_REGION)
+    table_questions = fetch_table_questions(args.table)
+    updated = build_updated_file(table_questions)
+
+    with open(QUESTIONS_FILE, "r", encoding="utf-8") as f:
+        current = json.load(f)
+
+    in_sync = current.get("questions") == updated["questions"]
+
+    if args.check:
+        if in_sync:
+            logger.info("✅ questions.json is in sync with the table.")
+            return 0
+        logger.error(
+            "❌ questions.json is OUT OF SYNC with the table. "
+            "Run: python scripts/export_quiz_questions.py"
+        )
+        return 1
+
+    if in_sync:
+        logger.info("Already in sync; nothing to write.")
+        return 0
+
+    with open(QUESTIONS_FILE, "w", encoding="utf-8") as f:
+        json.dump(updated, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    logger.info("✅ Wrote %d questions to %s", len(table_questions), QUESTIONS_FILE)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/app/api/mirrorgpt_routes.py
+++ b/src/app/api/mirrorgpt_routes.py
@@ -32,9 +32,16 @@ if TYPE_CHECKING:
 
 from ..core.enhanced_auth import get_user_with_profile
 from ..core.security import get_current_user, get_current_user_optional
-from ..services.dynamodb_service import DynamoDBService, get_dynamodb_service
+from ..services.dynamodb_service import (  # noqa: F401  (DynamoDBService patched in tests/conftest)
+    DynamoDBService,
+    get_dynamodb_service,
+)
 from ..services.mirror_orchestrator import MIRRORGPT_SYSTEM_PROMPT, MirrorOrchestrator
 from ..services.openai_service import ChatMessage, OpenAIService
+from ..services.quiz_questions_loader import (
+    get_quiz_questions as load_bundled_quiz_questions,
+)
+from ..services.quiz_questions_loader import load_quiz_data
 from .models import (
     ArchetypeAnalysisData,
     ArchetypeAnalysisRequest,
@@ -538,17 +545,17 @@ async def analyze_archetype(
 
 
 @router.get("/quiz/questions")
-async def get_quiz_questions(
-    orchestrator: MirrorOrchestrator = Depends(get_mirror_orchestrator),
-):
+async def get_quiz_questions():
     """
-    Get all active quiz questions
+    Get all active quiz questions.
+
+    Served from the bundled questions.json (static V1 content) instead of a
+    DynamoDB scan, so this is a fast, cold-start-friendly read. No orchestrator
+    dependency — avoids constructing an OpenAIService per request. Keep the
+    file in sync with the table via scripts/export_quiz_questions.py.
     """
     try:
-        # For now, we'll return the questions from DynamoDB
-        # If not found, we could fallback to a hardcoded list or return empty
-        questions = await orchestrator.dynamodb_service.get_quiz_questions()
-        return {"success": True, "data": questions}
+        return {"success": True, "data": load_bundled_quiz_questions()}
     except Exception as e:
         logger.error(f"Failed to get quiz questions: {str(e)}")
         raise HTTPException(
@@ -561,7 +568,6 @@ async def submit_archetype_quiz(
     request: ArchetypeQuizRequest,
     current_user: Optional[Dict[str, Any]] = Depends(get_current_user_optional),
     orchestrator: MirrorOrchestrator = Depends(get_mirror_orchestrator),
-    dynamodb_service: DynamoDBService = Depends(get_dynamodb_service),
 ):
     """
     Submit archetype quiz and calculate results server-side (V1 Spec)
@@ -574,10 +580,6 @@ async def submit_archetype_quiz(
 
     Supports both authenticated users and anonymous submissions.
     """
-    import json
-    import os
-    from pathlib import Path
-
     from ..services.quiz_scoring import calculate_quiz_result
     from ..services.quiz_submission import build_scoring_inputs
 
@@ -594,39 +596,14 @@ async def submit_archetype_quiz(
                 detail="Authentication required or anonymousId must be provided",
             )
 
-        # 2. Load questions from DynamoDB or fallback to questions.json
-        questions_list = []
-        questions_json = {}
-
-        try:
-            questions_data = await dynamodb_service.get_quiz_questions()
-            questions_list = questions_data if isinstance(questions_data, list) else []
-        except Exception as e:
-            logger.warning(
-                f"Failed to load questions from DynamoDB: {e}, using fallback"
-            )
-
-        # Fallback to questions.json if DynamoDB didn't provide questions
-        if not questions_list:
-            questions_file = Path(__file__).parent.parent / "data" / "questions.json"
-            if questions_file.exists():
-                with open(questions_file, "r") as f:
-                    questions_json = json.load(f)
-                    questions_list = questions_json.get("questions", [])
-            else:
-                raise HTTPException(
-                    status_code=500, detail="Quiz questions not available"
-                )
+        # 2. Load questions + config from the bundled questions.json (static V1
+        #    content baked into the deploy — no DynamoDB scan on the request
+        #    path). Keep it in sync with the table via the export script.
+        questions_json = load_quiz_data()
+        questions_list = questions_json.get("questions", [])
 
         if not questions_list:
             raise HTTPException(status_code=500, detail="No quiz questions found")
-
-        # If we got questions from DynamoDB, we still need archetypes from file
-        if not questions_json:
-            questions_file = Path(__file__).parent.parent / "data" / "questions.json"
-            if questions_file.exists():
-                with open(questions_file, "r") as f:
-                    questions_json = json.load(f)
 
         # 3. Extract quiz config for dynamic scoring
         quiz_config = questions_json.get("config", {})

--- a/src/app/services/quiz_questions_loader.py
+++ b/src/app/services/quiz_questions_loader.py
@@ -1,0 +1,38 @@
+"""Load quiz questions from the bundled questions.json (no DynamoDB at runtime).
+
+The archetype quiz is static V1 spec content, so the questions are baked into
+the deployment instead of read from DynamoDB on every request. This removes the
+cold-container ``table.scan()`` that made ``GET /quiz/questions`` (and the quiz
+submit path) slow on Lambda cold starts.
+
+The bundled file is the single source of truth at runtime. Keep it in sync with
+the ``quiz_questions`` DynamoDB table via ``scripts/export_quiz_questions.py``.
+"""
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List
+
+_QUESTIONS_FILE = Path(__file__).resolve().parent.parent / "data" / "questions.json"
+
+
+@lru_cache(maxsize=1)
+def load_quiz_data() -> Dict[str, Any]:
+    """Return the full parsed questions.json (questions + config + archetypes).
+
+    Cached for the life of the process (the file is immutable at runtime). Use
+    :func:`reset_cache` in tests that need to re-read after patching the file.
+    """
+    with open(_QUESTIONS_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_quiz_questions() -> List[Dict[str, Any]]:
+    """Return the list of quiz questions from the bundled file."""
+    return load_quiz_data().get("questions", [])
+
+
+def reset_cache() -> None:
+    """Test-only: clear the cached file contents."""
+    load_quiz_data.cache_clear()

--- a/tests/test_quiz_questions_loader.py
+++ b/tests/test_quiz_questions_loader.py
@@ -1,0 +1,88 @@
+"""Tests for the bundled quiz-questions loader and the GET /quiz/questions route.
+
+The quiz is served from src/app/data/questions.json (baked into the deploy) to
+avoid a DynamoDB scan on the request path. These tests pin the bundled file's
+integrity and that the endpoint serves it without any DynamoDB dependency.
+"""
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app.handler import app
+from src.app.services import quiz_questions_loader as loader
+
+VALID_ARCHETYPES = {"Seeker", "Guardian", "Flamebearer", "Weaver"}
+
+
+@pytest.fixture(autouse=True)
+def _reset_loader_cache():
+    loader.reset_cache()
+    yield
+    loader.reset_cache()
+
+
+def test_loader_returns_five_questions():
+    questions = loader.get_quiz_questions()
+    assert len(questions) == 5
+    assert sorted(q["id"] for q in questions) == [1, 2, 3, 4, 5]
+
+
+def test_loader_is_cached():
+    assert loader.load_quiz_data() is loader.load_quiz_data()
+
+
+def test_every_option_maps_to_a_valid_archetype():
+    for q in loader.get_quiz_questions():
+        opts = q["options"]
+        assert len(opts) == 4
+        for opt in opts:
+            assert opt["archetype"] in VALID_ARCHETYPES
+            # Each option must carry display text (text) or image label (label).
+            assert opt.get("text") or opt.get("label")
+
+
+def test_core_questions_are_1_3_5():
+    core = sorted(q["id"] for q in loader.get_quiz_questions() if q.get("core"))
+    assert core == [1, 3, 5]
+
+
+def test_config_and_archetypes_present():
+    data = loader.load_quiz_data()
+    assert set(data["config"]["archetypes"]) == VALID_ARCHETYPES
+    assert set(data["archetypes"].keys()) == {a.lower() for a in VALID_ARCHETYPES}
+
+
+def test_get_quiz_questions_route_serves_bundled_no_dynamodb():
+    client = TestClient(app)
+    resp = client.get("/api/mirrorgpt/quiz/questions")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert len(body["data"]) == 5
+    assert body["data"] == loader.get_quiz_questions()
+
+
+@pytest.mark.skipif(
+    not os.getenv("AWS_ACCESS_KEY_ID") and not os.getenv("AWS_PROFILE"),
+    reason="no AWS credentials; live-sync check is integration-only",
+)
+def test_bundled_file_in_sync_with_live_table():
+    """Integration: the bundled questions must match the DynamoDB table.
+
+    Mirrors `scripts/export_quiz_questions.py --check`. Skipped without creds.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    script = (
+        Path(__file__).resolve().parent.parent / "scripts" / "export_quiz_questions.py"
+    )
+    spec = importlib.util.spec_from_file_location("export_quiz_questions", script)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    table_questions = mod.fetch_table_questions(mod.TABLE_NAME)
+    assert loader.get_quiz_questions() == table_questions


### PR DESCRIPTION
GET /mirrorgpt/quiz/questions (and the quiz submit path) ran a full table.scan() on the quiz_questions table. The in-process cache is per Lambda container, so cold/parallel containers re-scanned — making the "quiz load" feel slow (250-450ms warm, ~6s when stacked on a cold start).

The archetype quiz is static V1 content, so bake it into the deploy:
- quiz_questions_loader: load src/app/data/questions.json once (lru_cache) and serve it. No DynamoDB on the request path.
- GET /quiz/questions: serve the bundled questions and drop the orchestrator dependency (also stops constructing an OpenAIService per request).
- submit path: load questions + config from the bundled file (removes the scan and the DDB/file fallback); drop the now-unused dynamodb_service dep.
- scripts/export_quiz_questions.py: sync the file from the table; --check exits non-zero when out of sync (for CI / pre-deploy).

Trade-off: questions are frozen at deploy time; re-run the export script when the table changes. Bundled file is currently in sync with prod (verified). Adds loader/route tests + an optional live-sync integration test.