### PR TITLE
perf: cache OpenAI service + orchestrator; raise API Lambda memory

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -286,6 +286,13 @@ provider:
 functions:
   api:
     handler: src/app/handler.handler
+    # Lambda CPU scales with memory: ~1024MB ≈ 0.58 vCPU, 1769MB = 1 full vCPU.
+    # The API's cold-start init (~5.6s) and request work are CPU-bound (boto3 /
+    # openai imports, service construction), so 1769 roughly doubles CPU vs the
+    # 1024 default — faster cold starts and handlers. Memory headroom is large
+    # (avg ~238MB used), so this buys CPU, not RAM. Shorter duration often makes
+    # the per-ms cost increase close to net-neutral. Tune up/down as needed.
+    memorySize: 1769
     events:
       # ---- Public routes (no authorizer) ----
       # Health checks (monitors / load balancers).

--- a/src/app/api/mirrorgpt_routes.py
+++ b/src/app/api/mirrorgpt_routes.py
@@ -9,6 +9,7 @@ import os
 import re
 import uuid
 from datetime import datetime, timezone
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 # Strict allow-list for names that get interpolated into LLM prompt text.
@@ -37,7 +38,11 @@ from ..services.dynamodb_service import (  # noqa: F401  (DynamoDBService patche
     get_dynamodb_service,
 )
 from ..services.mirror_orchestrator import MIRRORGPT_SYSTEM_PROMPT, MirrorOrchestrator
-from ..services.openai_service import ChatMessage, OpenAIService
+from ..services.openai_service import (  # noqa: F401  (OpenAIService patched in tests/conftest)
+    ChatMessage,
+    OpenAIService,
+    get_openai_service,
+)
 from ..services.quiz_questions_loader import (
     get_quiz_questions as load_bundled_quiz_questions,
 )
@@ -151,11 +156,16 @@ def generate_conversation_title(message: str, max_length: int = 50) -> str:
 router = APIRouter(prefix="/mirrorgpt", tags=["MirrorGPT"])
 
 
+@lru_cache(maxsize=1)
 def get_mirror_orchestrator() -> MirrorOrchestrator:
-    """Dependency injection for MirrorOrchestrator"""
-    dynamodb_service = get_dynamodb_service()
-    openai_service = OpenAIService()
-    return MirrorOrchestrator(dynamodb_service, openai_service)
+    """Dependency injection for MirrorOrchestrator.
+
+    Cached process-wide: the orchestrator is stateless (user/session data is
+    passed per call), and its deps — DynamoDBService, OpenAIService — are
+    themselves cached singletons. Caching avoids rebuilding the OpenAI httpx
+    clients and re-loading ArchetypeEngine definitions on every request.
+    """
+    return MirrorOrchestrator(get_dynamodb_service(), get_openai_service())
 
 
 def get_conversation_service() -> "ConversationService":
@@ -182,10 +192,9 @@ def _schedule_summary_refresh(
     async def _run() -> None:
         try:
             from ..services.conversation_summarizer import ConversationSummarizer
-            from ..services.openai_service import OpenAIService
 
             summarizer = ConversationSummarizer(
-                openai_service=OpenAIService(),
+                openai_service=get_openai_service(),
                 conversation_service=conversation_service,
             )
             # summarize_if_stale handles "do we need to" internally.
@@ -345,7 +354,6 @@ async def _try_lazy_summarize(
             DEFAULT_FIRST_SUMMARY_AT,
             ConversationSummarizer,
         )
-        from ..services.openai_service import OpenAIService
     except Exception as e:  # noqa: BLE001
         logger.warning(f"continuity: summarizer import failed: {e}")
         return
@@ -355,7 +363,7 @@ async def _try_lazy_summarize(
 
     try:
         summarizer = ConversationSummarizer(
-            openai_service=OpenAIService(),
+            openai_service=get_openai_service(),
             conversation_service=conversation_service,
         )
         await summarizer.summarize_if_stale(

--- a/src/app/services/openai_service.py
+++ b/src/app/services/openai_service.py
@@ -5,6 +5,7 @@ OpenAI service for AI chat completions and conversation management
 import asyncio
 import logging
 import os
+from functools import lru_cache
 from typing import AsyncGenerator, Dict, List, Optional, cast
 
 from openai import AsyncOpenAI, OpenAI
@@ -384,3 +385,15 @@ class OpenAIService(IMirrorChatRepository):
         except Exception as e:
             logger.error(f"OpenAI API async error: {str(e)}")
             raise InternalServerError(f"Chat service unavailable: {str(e)}")
+
+
+@lru_cache(maxsize=1)
+def get_openai_service() -> "OpenAIService":
+    """Return a process-wide OpenAIService singleton.
+
+    OpenAIService.__init__ builds both a sync OpenAI and an AsyncOpenAI httpx
+    client. Constructing it per request (as several MirrorGPT call sites did)
+    rebuilds those clients every time. Caching it — like get_dynamodb_service /
+    get_echo_service — reuses the clients across warm-container invocations.
+    """
+    return OpenAIService()

--- a/src/app/services/soul_ping_service.py
+++ b/src/app/services/soul_ping_service.py
@@ -28,7 +28,7 @@ from ..models.soul_ping import V1_CATEGORIES, SoulPing, SoulPingCategory
 from ..models.user_profile import UserProfile
 from .conversation_service import ConversationService
 from .dynamodb_service import DynamoDBService, get_dynamodb_service
-from .openai_service import ChatMessage, OpenAIService
+from .openai_service import ChatMessage, OpenAIService, get_openai_service
 from .sns_service import SNSService
 
 logger = logging.getLogger(__name__)
@@ -133,7 +133,7 @@ class SoulPingService:
         sns_service: Optional[SNSService] = None,
     ):
         self.db = dynamodb_service or get_dynamodb_service()
-        self.openai = openai_service or OpenAIService()
+        self.openai = openai_service or get_openai_service()
         self.conversations = conversation_service or ConversationService()
         self.sns = sns_service or SNSService()
 

--- a/tests/test_service_singletons.py
+++ b/tests/test_service_singletons.py
@@ -1,0 +1,31 @@
+"""The OpenAI service and MirrorGPT orchestrator are process-wide singletons.
+
+Constructing OpenAIService rebuilds two httpx clients; the orchestrator also
+loads ArchetypeEngine definitions. Caching them (like get_dynamodb_service)
+avoids that per request. These tests pin the caching so a future change can't
+silently reintroduce per-request construction.
+"""
+
+from unittest.mock import patch
+
+from src.app.services.openai_service import get_openai_service
+
+
+def test_get_openai_service_is_cached():
+    get_openai_service.cache_clear()
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}):
+        a = get_openai_service()
+        b = get_openai_service()
+    assert a is b
+
+
+def test_get_mirror_orchestrator_is_cached():
+    from src.app.api.mirrorgpt_routes import get_mirror_orchestrator
+
+    get_mirror_orchestrator.cache_clear()
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}):
+        a = get_mirror_orchestrator()
+        b = get_mirror_orchestrator()
+    assert a is b
+    # Reuses the cached OpenAI singleton rather than building a new client.
+    assert a.openai_service is get_openai_service()


### PR DESCRIPTION
Two cold-start / per-request latency wins for the MirrorGPT API.

#1 Cache services (stop rebuilding httpx clients per request):
- OpenAIService.__init__ builds a sync OpenAI and an AsyncOpenAI httpx client. Several MirrorGPT call sites constructed it per request. Add a cached get_openai_service() (like get_dynamodb_service) and use it in the orchestrator factory, the summary-refresh tasks, and soul_ping_service.
- @lru_cache get_mirror_orchestrator: the orchestrator is stateless (user data is passed per call) and its deps are cached singletons, so reuse one instance — also avoids re-loading ArchetypeEngine definitions each request. (OpenAIService/DynamoDBService imports kept for the conftest patch targets.)

#4 Raise API Lambda memory 1024 -> 1769 MB:
- Lambda CPU scales with memory; 1769MB = 1 full vCPU (~2x the 1024 default). Cold-start init (~5.6s) and request work are CPU-bound, so this speeds both. Memory headroom is large (avg ~238MB used) — this buys CPU, not RAM.

Adds tests asserting both factories return cached singletons.