### PR TITLE
perf: lazy SNS client (#5) + parallelize chat/greeting DDB I/O (#6, #7)

### DIFF
--- a/src/app/api/mirrorgpt_routes.py
+++ b/src/app/api/mirrorgpt_routes.py
@@ -442,21 +442,25 @@ async def mirrorgpt_chat(
         # Save the user message and AI response to conversation
         if conversation_id:
             try:
-                # Save user message with MirrorGPT analysis
-                await conversation_service.add_message_with_mirrorgpt_analysis(
-                    conversation_id=conversation_id,
-                    user_id=current_user["id"],
-                    role="user",
-                    content=request.message,
-                    mirrorgpt_analysis=result.get("mirrorgpt_analysis"),
-                )
-
-                # Save AI response
-                await conversation_service.add_message(
-                    conversation_id=conversation_id,
-                    user_id=current_user["id"],
-                    role="assistant",
-                    content=result["response"],
+                # The user-message and assistant-message writes are independent
+                # DDB items — persist them concurrently (one round-trip instead
+                # of two). Both must complete before we return: on Lambda the
+                # container freezes after the response, so a fire-and-forget
+                # write would be lost.
+                await asyncio.gather(
+                    conversation_service.add_message_with_mirrorgpt_analysis(
+                        conversation_id=conversation_id,
+                        user_id=current_user["id"],
+                        role="user",
+                        content=request.message,
+                        mirrorgpt_analysis=result.get("mirrorgpt_analysis"),
+                    ),
+                    conversation_service.add_message(
+                        conversation_id=conversation_id,
+                        user_id=current_user["id"],
+                        role="assistant",
+                        content=result["response"],
+                    ),
                 )
 
                 logger.debug(f"Saved messages to conversation {conversation_id}")
@@ -1142,19 +1146,23 @@ async def get_session_greeting(
     """
 
     try:
-        # Get user's current profile and history
-        profile = await orchestrator._get_user_profile(current_user["id"])
-        recent_signals = await orchestrator._get_recent_signals_from_messages(
-            current_user["id"], limit=5
-        )
-        recent_moments = await orchestrator.dynamodb_service.get_user_mirror_moments(
-            current_user["id"], limit=3
-        )
-
-        # Load continuity memory (summaries of prior conversations).
-        continuity = await _load_continuity_context(
-            user_id=current_user["id"],
-            conversation_service=conversation_service,
+        # These four reads are independent — run them concurrently instead of
+        # sequentially (greeting was ~5 serial DDB round-trips on the read path).
+        (
+            profile,
+            recent_signals,
+            recent_moments,
+            continuity,
+        ) = await asyncio.gather(
+            orchestrator._get_user_profile(current_user["id"]),
+            orchestrator._get_recent_signals_from_messages(current_user["id"], limit=5),
+            orchestrator.dynamodb_service.get_user_mirror_moments(
+                current_user["id"], limit=3
+            ),
+            _load_continuity_context(
+                user_id=current_user["id"],
+                conversation_service=conversation_service,
+            ),
         )
 
         # Extract user context

--- a/src/app/services/sns_service.py
+++ b/src/app/services/sns_service.py
@@ -31,24 +31,35 @@ def _warn_sync_sns_call(method_name: str) -> None:
 
 class SNSService:
     def __init__(self):
-        # Tune boto3 client for high-concurrency FastAPI/Lambda:
-        # - max_pool_connections=50 prevents pool exhaustion under push bursts
-        #   (e.g. broadcast topic publish + per-device direct publishes).
-        # - retries=adaptive backs off intelligently on SNS throttling.
-        self.sns = boto3.client(
-            "sns",
-            region_name=os.getenv("AWS_SNS_REGION", "us-east-1"),
-            config=Config(
-                max_pool_connections=50,
-                retries={"max_attempts": 5, "mode": "adaptive"},
-            ),
-        )
+        # The boto3 SNS client is built lazily (see `sns` property) — its
+        # construction resolves credentials/endpoints and is a measurable
+        # cold-start cost. Routers instantiate SNSService at import, but most
+        # requests never publish, so defer it to first use.
+        self._sns = None
         self.topic_arn = os.getenv("SNS_TOPIC_ARN")
         # Support both platform-specific and generic ARNs
         self.android_app_arn = os.getenv("SNS_ANDROID_APP_ARN") or os.getenv(
             "SNS_PLATFORM_APP_ARN"
         )
         self.ios_app_arn = os.getenv("SNS_IOS_APP_ARN")
+
+    @property
+    def sns(self) -> Any:
+        """Lazily build (and cache) the tuned boto3 SNS client on first use.
+
+        - max_pool_connections=50 prevents pool exhaustion under push bursts.
+        - retries=adaptive backs off intelligently on SNS throttling.
+        """
+        if self._sns is None:
+            self._sns = boto3.client(
+                "sns",
+                region_name=os.getenv("AWS_SNS_REGION", "us-east-1"),
+                config=Config(
+                    max_pool_connections=50,
+                    retries={"max_attempts": 5, "mode": "adaptive"},
+                ),
+            )
+        return self._sns
 
     def _get_platform_arn(self, platform: str) -> Optional[str]:
         """Get the appropriate Platform Application ARN based on platform."""

--- a/tests/test_sns_async_boto3.py
+++ b/tests/test_sns_async_boto3.py
@@ -28,7 +28,7 @@ def sns_service_with_mock_client():
         from src.app.services.sns_service import SNSService
 
         service = SNSService()
-        service.sns = mock_client
+        service._sns = mock_client  # inject the mock as the lazily-built client
         yield service, mock_client
 
 
@@ -40,7 +40,8 @@ def test_client_constructed_with_max_pool_connections():
         mock_boto3.return_value = MagicMock()
         from src.app.services.sns_service import SNSService
 
-        SNSService()
+        # The client is built lazily; access .sns to trigger construction.
+        _ = SNSService().sns
 
     args, kwargs = mock_boto3.call_args
     assert args[0] == "sns"
@@ -130,3 +131,18 @@ def test_sync_publish_to_topic_still_works(sns_service_with_mock_client):
 
     assert msg_id == "msg-sync"
     mock_client.publish.assert_called_once()
+
+
+def test_sns_client_is_lazy():
+    """The boto3 SNS client must not be built until first use (cold-start perf)."""
+    from unittest.mock import patch
+
+    from src.app.services.sns_service import SNSService
+
+    with patch("src.app.services.sns_service.boto3.client") as mock_client:
+        svc = SNSService()
+        assert mock_client.call_count == 0  # not built at construction
+        _ = svc.sns  # first access builds it
+        assert mock_client.call_count == 1
+        _ = svc.sns  # cached
+        assert mock_client.call_count == 1


### PR DESCRIPTION
#5 Lazy-init the boto3 SNS client: SNSService is constructed at import by
   several routers, but building the boto3 client resolves credentials/
   endpoints — a cold-start cost most requests never need. Defer it to first
   use via a cached `sns` property. No call-site changes.

#6 Chat: persist the user-message and assistant-message writes concurrently
   (asyncio.gather) instead of two sequential round-trips. Both still complete
   before responding — on Lambda the container freezes after the response, so a
   fire-and-forget write would be lost; gather is the safe win.

#7 Greeting: the profile / recent-signals / mirror-moments / continuity reads
   were ~5 sequential DDB round-trips. Run the four independent reads
   concurrently with asyncio.gather.

Adds an SNS lazy-construction test; updates SNS tests for the property.