### PR TITLE
perf: trim auth hot paths (login 2nd Cognito call; confirm-email para…

### DIFF
--- a/src/app/controllers/auth_controller.py
+++ b/src/app/controllers/auth_controller.py
@@ -2,8 +2,11 @@
 Authentication controller - handles all auth-related endpoints
 """
 
+import asyncio
 import logging
 from typing import Any, Dict
+
+from jose import jwt
 
 from ..api.models import (
     AuthResponse,
@@ -86,17 +89,20 @@ class AuthController:
             email=payload.email, password=payload.password
         )
 
-        # Get user profile from Cognito
-        user_profile = await self.cognito_service.get_user_by_email(payload.email)
-        user_attrs = user_profile["userAttributes"]
-        user_id = user_profile["username"]
+        # Build the user from the ID token we just received instead of a second
+        # Cognito GetUser round-trip (~150-250ms saved on a high-volume path).
+        # The token is trusted — Cognito issued it in the call above over TLS —
+        # so we read its claims directly. `cognito:username` preserves the exact
+        # user_id value the previous get_user_by_email().username returned.
+        claims = jwt.get_unverified_claims(auth_result["idToken"])
+        user_id = claims.get("cognito:username") or claims.get("sub", "")
 
         user = UserBasic(
             id=user_id,
-            email=user_attrs.get("email", payload.email),
-            fullName=f"{user_attrs.get('given_name', '')} "
-            f"{user_attrs.get('family_name', '')}".strip(),
-            isVerified=user_attrs.get("email_verified", "false").lower() == "true",
+            email=claims.get("email", payload.email),
+            fullName=f"{claims.get('given_name', '')} "
+            f"{claims.get('family_name', '')}".strip(),
+            isVerified=bool(claims.get("email_verified", False)),
         )
 
         # Just record login activity - don't create profiles during login
@@ -220,56 +226,60 @@ class AuthController:
                     f"Created user profile in DynamoDB for user: {user_profile.user_id}"
                 )
 
-                # Apply terms acceptance passed through from registration
-                if payload.termsAcceptedAt:
+                # These three post-profile steps are independent — run them
+                # concurrently instead of sequentially. Each owns its error
+                # handling (a failure must not fail confirmation or the others).
+                uid = user_profile.user_id
+
+                async def _apply_terms() -> None:
+                    if not payload.termsAcceptedAt:
+                        return
                     try:
                         await self.user_service.update_user_profile(
-                            user_profile.user_id,
+                            uid,
                             {
                                 "terms_accepted_at": payload.termsAcceptedAt,
                                 "terms_version": "1.0",
                             },
                         )
-                        logger.info(
-                            f"Applied terms to user profile: {user_profile.user_id}"
-                        )
+                        logger.info(f"Applied terms to user profile: {uid}")
                     except Exception as terms_error:
-                        logger.error(
-                            f"Failed to apply terms for {user_profile.user_id}: "
-                            f"{terms_error}"
-                        )
-                        # Don't fail confirmation if terms update fails
+                        logger.error(f"Failed to apply terms for {uid}: {terms_error}")
 
-                # Link anonymous quiz data if anonymousId was provided
-                if payload.anonymousId:
+                async def _link_anonymous() -> None:
+                    if not payload.anonymousId:
+                        return
                     try:
                         anon_id = f"anon_{payload.anonymousId}"
                         link_results = await self.linking_service.link_anonymous_data(
-                            anonymous_id=anon_id, user_id=user_profile.user_id
+                            anonymous_id=anon_id, user_id=uid
                         )
                         logger.info(
-                            f"Anonymous data linking completed for "
-                            f"{user_profile.user_id}: {link_results}"
+                            f"Anonymous data linking completed for {uid}: "
+                            f"{link_results}"
                         )
                     except Exception as link_error:
                         logger.error(f"Failed to link anonymous data: {link_error}")
-                        # Don't fail email confirmation if linking fails
 
-                # Back-link recipient rows that other users created with this
-                # email before this user signed up. Without this, their inbox
-                # is silent because the recipient row's recipient_user_id is None.
-                try:
-                    await self.echo_service.link_user_to_recipients(
-                        user_id=user_profile.user_id,
-                        email=user_profile.email,
-                    )
-                except Exception as backlink_error:
-                    logger.error(
-                        f"Failed to back-link recipients for "
-                        f"{user_profile.user_id}: {backlink_error}"
-                    )
-                    # Don't fail confirmation; the offline backfill script
-                    # (scripts/backfill_recipient_user_id.py) will recover.
+                async def _backlink_recipients() -> None:
+                    # Back-link recipient rows that other users created with this
+                    # email before this user signed up. Without this, their inbox
+                    # is silent (recipient row's recipient_user_id is None).
+                    try:
+                        await self.echo_service.link_user_to_recipients(
+                            user_id=uid, email=user_profile.email
+                        )
+                    except Exception as backlink_error:
+                        logger.error(
+                            f"Failed to back-link recipients for {uid}: "
+                            f"{backlink_error}"
+                        )
+                        # The offline backfill script recovers
+                        # (scripts/backfill_recipient_user_id.py).
+
+                await asyncio.gather(
+                    _apply_terms(), _link_anonymous(), _backlink_recipients()
+                )
 
             except Exception as e:
                 # Log the error but don't fail the email confirmation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,11 +36,29 @@ mock_cognito.sign_up.return_value = {
     "UserConfirmed": False,
 }
 
+# Login now reads the ID token claims instead of a 2nd Cognito GetUser, so the
+# mocked IdToken must be a real (decodable) JWT. Signature is irrelevant — the
+# controller uses jwt.get_unverified_claims.
+from jose import jwt as _jose_jwt  # noqa: E402
+
+_TEST_ID_TOKEN = _jose_jwt.encode(
+    {
+        "cognito:username": "test@example.com",
+        "sub": "test-user-123",
+        "email": "test@example.com",
+        "given_name": "Test",
+        "family_name": "User",
+        "email_verified": True,
+    },
+    "test-secret",
+    algorithm="HS256",
+)
+
 mock_cognito.admin_initiate_auth.return_value = {
     "AuthenticationResult": {
         "AccessToken": "test-access-token",
         "RefreshToken": "test-refresh-token",
-        "IdToken": "test-id-token",
+        "IdToken": _TEST_ID_TOKEN,
     }
 }
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -59,6 +59,22 @@ def test_login_success(client: TestClient, mock_cognito_client, sample_login_dat
     assert "data" in data
     assert data["data"]["tokens"]["accessToken"] == "test-access-token"
     assert data["data"]["tokens"]["refreshToken"] == "test-refresh-token"
+    # User is built from the ID token claims, preserving the prior shape.
+    user = data["data"]["user"]
+    assert user["id"] == "test@example.com"  # cognito:username claim
+    assert user["email"] == "test@example.com"
+    assert user["fullName"] == "Test User"
+    assert user["isVerified"] is True
+
+
+def test_login_does_not_make_second_cognito_call(
+    client: TestClient, mock_cognito_client, sample_login_data
+):
+    """Login reads the ID token instead of a 2nd Cognito GetUser round-trip."""
+    mock_cognito_client.admin_get_user.reset_mock()
+    response = client.post("/api/auth/login", json=sample_login_data)
+    assert response.status_code == 200
+    mock_cognito_client.admin_get_user.assert_not_called()
 
 
 def test_login_invalid_credentials(


### PR DESCRIPTION
…llel I/O)

C6 login (~543ms, highest-volume auth path): the handler made two sequential Cognito calls — authenticate_user then get_user_by_email. authenticate_user already returns the ID token, whose claims carry everything the response needs. Build the user from those claims (jwt.get_unverified_claims) and drop the second round-trip. The token is trusted (Cognito issued it over TLS in the call above). `cognito:username` preserves the exact user_id the old code used, so record_login_activity and the response shape are unchanged.

C7 confirm-email (~689ms): the three independent post-profile steps — terms update, anonymous-data linking, recipient back-link — ran sequentially. Run them concurrently with asyncio.gather; each keeps its own error handling so a failure can't fail confirmation or the others. (The two Cognito calls stay sequential — no token is issued on confirm, so get_user_by_email is required.)

Tests: assert login builds the user from ID-token claims and makes no second Cognito GetUser call; the mocked IdToken is now a real decodable JWT.